### PR TITLE
refactor: introduce the apply-context frame stack, dual-written with the attribution flags

### DIFF
--- a/packages/editor/src/editor/mutation-batcher.test.ts
+++ b/packages/editor/src/editor/mutation-batcher.test.ts
@@ -110,6 +110,7 @@ function createOperationEvent(operation: EngineOperation): OperationEvent {
     withHistory: false,
     undoStepId: undefined,
     origin: 'local',
+    context: [],
   }
 }
 

--- a/packages/editor/src/editor/remote-patches.ts
+++ b/packages/editor/src/editor/remote-patches.ts
@@ -36,7 +36,7 @@ export function setupRemotePatches({
     bufferedPatches = []
     let changed = false
 
-    withRemoteChanges(editor, () => {
+    withRemoteChanges(editor, 'patches', () => {
       withoutNormalizing(editor, () => {
         withoutPatching(editor, () => {
           pluginWithoutHistory(editor, () => {

--- a/packages/editor/src/editor/sync-machine.test.ts
+++ b/packages/editor/src/editor/sync-machine.test.ts
@@ -1,0 +1,93 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {describe, expect, test, vi} from 'vitest'
+import {createActor} from 'xstate'
+import {createBehaviorApiPlugin} from '../engine-plugins/engine-plugin.behavior-api'
+import {updateSelectionPlugin} from '../engine-plugins/engine-plugin.update-selection'
+import type {ApplyContextFrame} from '../engine/core/apply-context'
+import {subscribeToOperations} from '../engine/core/operation-channel'
+import {createEditor} from '../engine/create-editor'
+import type {PortableTextEditorEngine} from '../types/editor-engine'
+import {editorMachine} from './editor-machine'
+import {syncMachine} from './sync-machine'
+
+function createTestEngine(keyGenerator: () => string) {
+  const schema = compileSchema(defineSchema({}))
+  const e: any = createEditor()
+  e.containers = new Map()
+  e.blockIndexMap = new Map()
+  e.verifiedUniqueChildGroups = new Set()
+  e.snapshot = {
+    blockIndexMap: e.blockIndexMap,
+    context: {
+      containers: new Map(),
+      converters: [],
+      keyGenerator,
+      readOnly: false,
+      schema,
+      selection: null,
+      value: [],
+    },
+    decoratorState: {},
+  }
+
+  // Only wired for the plugin closures `updateSelectionPlugin` and
+  // `createBehaviorApiPlugin` capture; the sync flow under test never sends
+  // it an event.
+  const editorActor = createActor(editorMachine, {
+    input: {schema, keyGenerator},
+  })
+
+  const behaviorApiPlugin = createBehaviorApiPlugin(editorActor)
+  const editor: PortableTextEditorEngine = behaviorApiPlugin(
+    updateSelectionPlugin({editorActor, editor: e}),
+  )
+
+  return {editor, schema}
+}
+
+describe('sync machine', () => {
+  test('an editor created without an initial value tags its first real value sync `update-value`, not `initial-sync`', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, schema} = createTestEngine(keyGenerator)
+
+    const remoteFrames: Array<ApplyContextFrame> = []
+    subscribeToOperations(editor, (event) => {
+      for (const frame of event.context) {
+        if (frame.kind === 'remote') {
+          remoteFrames.push(frame)
+        }
+      }
+    })
+
+    const actor = createActor(syncMachine, {
+      input: {
+        initialValue: undefined,
+        keyGenerator,
+        schema,
+        readOnly: false,
+        editorEngine: editor,
+      },
+    })
+    actor.start()
+
+    actor.send({
+      type: 'update value',
+      value: [
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 's1', text: 'foo', marks: []}],
+        },
+      ],
+    })
+
+    await vi.waitFor(() => {
+      expect(remoteFrames.length).toBeGreaterThan(0)
+    })
+
+    expect(remoteFrames).toEqual([{kind: 'remote', source: 'update-value'}])
+  })
+})

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -16,6 +16,7 @@ import {
 import {withRemoteChanges} from '../engine-plugins/engine-plugin.remote-changes'
 import {pluginWithoutHistory} from '../engine-plugins/engine-plugin.without-history'
 import {withoutPatching} from '../engine-plugins/engine-plugin.without-patching'
+import type {ApplyContextFrame} from '../engine/core/apply-context'
 import {start} from '../engine/editor/start'
 import {withoutNormalizing} from '../engine/editor/without-normalizing'
 import type {Node} from '../engine/interfaces/node'
@@ -84,6 +85,8 @@ const syncValueCallback: CallbackLogicFunction<
 const syncValueLogic = fromCallback(syncValueCallback)
 
 export type SyncActor = ActorRefFrom<typeof syncMachine>
+
+type RemoteSyncSource = Extract<ApplyContextFrame, {kind: 'remote'}>['source']
 
 /**
  * Sync value with the editor state
@@ -451,11 +454,19 @@ async function updateValue({
   let isValid = true
 
   const hadSelection = !!editorEngine.snapshot.context.selection
+  // `streamBlocks` is true only for a fresh editor's first value sync
+  // (`initialValueSynced` never flips back); an editor created without an
+  // initial value never runs that sync, so its first real value is tagged
+  // `update-value` instead of `initial-sync`.
+  const remoteSource: RemoteSyncSource = streamBlocks
+    ? 'initial-sync'
+    : 'update-value'
 
   if (!value || value.length === 0) {
     clearEditor({
       editorEngine,
       doneSyncing,
+      remoteSource,
     })
 
     isChanged = true
@@ -472,6 +483,7 @@ async function updateValue({
         isChanged = removeExtraBlocks({
           editorEngine,
           value,
+          remoteSource,
         })
 
         const processBlocks = async () => {
@@ -488,6 +500,7 @@ async function updateValue({
               index: currentBlockIndex,
               editorEngine,
               value,
+              remoteSource,
             })
 
             isChanged = blockChanged || isChanged
@@ -511,6 +524,7 @@ async function updateValue({
       isChanged = removeExtraBlocks({
         editorEngine,
         value,
+        remoteSource,
       })
 
       let index = 0
@@ -523,6 +537,7 @@ async function updateValue({
           index,
           editorEngine,
           value,
+          remoteSource,
         })
 
         isChanged = blockChanged || isChanged
@@ -604,11 +619,13 @@ async function* getStreamedBlocks({value}: {value: Array<PortableTextBlock>}) {
 function clearEditor({
   editorEngine,
   doneSyncing,
+  remoteSource,
 }: {
   editorEngine: PortableTextEditorEngine
   doneSyncing: boolean
+  remoteSource: RemoteSyncSource
 }) {
-  withRemoteChanges(editorEngine, () => {
+  withRemoteChanges(editorEngine, remoteSource, () => {
     withoutNormalizing(editorEngine, () => {
       pluginWithoutHistory(editorEngine, () => {
         withoutPatching(editorEngine, () => {
@@ -642,13 +659,15 @@ function clearEditor({
 function removeExtraBlocks({
   editorEngine,
   value,
+  remoteSource,
 }: {
   editorEngine: PortableTextEditorEngine
   value: Array<PortableTextBlock>
+  remoteSource: RemoteSyncSource
 }) {
   let isChanged = false
 
-  withRemoteChanges(editorEngine, () => {
+  withRemoteChanges(editorEngine, remoteSource, () => {
     withoutNormalizing(editorEngine, () => {
       withoutPatching(editorEngine, () => {
         const childrenLength = editorEngine.snapshot.context.value.length
@@ -681,6 +700,7 @@ function syncBlock({
   index,
   editorEngine,
   value,
+  remoteSource,
 }: {
   context: {
     keyGenerator: () => string
@@ -693,6 +713,7 @@ function syncBlock({
   index: number
   editorEngine: PortableTextEditorEngine
   value: Array<PortableTextBlock>
+  remoteSource: RemoteSyncSource
 }) {
   const oldEngineBlock = editorEngine.snapshot.context.value.at(index)
   const oldBlock = editorEngine.snapshot.context.value.at(index)
@@ -715,7 +736,7 @@ function syncBlock({
         schemaTypes: context.schema,
       })
 
-      withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, remoteSource, () => {
         withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             editorEngine.apply({
@@ -800,7 +821,7 @@ function syncBlock({
     if (oldBlock._key === block._key && oldBlock._type === block._type) {
       debug.syncValue('Updating block', oldBlock, repairedBlock)
 
-      withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, remoteSource, () => {
         withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             updateBlock({
@@ -816,7 +837,7 @@ function syncBlock({
     } else {
       debug.syncValue('Replacing block', oldBlock, repairedBlock)
 
-      withRemoteChanges(editorEngine, () => {
+      withRemoteChanges(editorEngine, remoteSource, () => {
         withoutNormalizing(editorEngine, () => {
           withoutPatching(editorEngine, () => {
             replaceBlock({

--- a/packages/editor/src/engine-plugins/engine-plugin.redoing.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.redoing.ts
@@ -7,10 +7,12 @@ export function pluginRedoing(
   const prev = editor.isRedoing
 
   editor.isRedoing = true
+  editor.applyContext.push(Object.freeze({kind: 'redo'}))
 
   try {
     fn()
   } finally {
+    editor.applyContext.pop()
     editor.isRedoing = prev
   }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.remote-changes.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.remote-changes.ts
@@ -1,14 +1,18 @@
+import type {ApplyContextFrame} from '../engine/core/apply-context'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 
 export function withRemoteChanges(
   editor: PortableTextEditorEngine,
+  source: Extract<ApplyContextFrame, {kind: 'remote'}>['source'],
   fn: () => void,
 ): void {
   const prev = editor.isProcessingRemoteChanges
   editor.isProcessingRemoteChanges = true
+  editor.applyContext.push(Object.freeze({kind: 'remote', source}))
   try {
     fn()
   } finally {
+    editor.applyContext.pop()
     editor.isProcessingRemoteChanges = prev
   }
 }

--- a/packages/editor/src/engine-plugins/engine-plugin.undoing.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.undoing.ts
@@ -7,10 +7,12 @@ export function pluginUndoing(
   const prev = editor.isUndoing
 
   editor.isUndoing = true
+  editor.applyContext.push(Object.freeze({kind: 'undo'}))
 
   try {
     fn()
   } finally {
+    editor.applyContext.pop()
     editor.isUndoing = prev
   }
 }

--- a/packages/editor/src/engine/core/apply-context.ts
+++ b/packages/editor/src/engine/core/apply-context.ts
@@ -1,0 +1,37 @@
+import type {OperationOrigin} from './operation-channel'
+
+/**
+ * A frame pushed onto `editor.applyContext` for the duration of an
+ * attribution bracket (remote changes, undo, redo, normalization). Brackets
+ * nest, so a normalization that fires while replaying a remote patch pushes
+ * a `normalization` frame on top of the still-active `remote` one; both
+ * stay visible to `getOrigin` below instead of only the innermost.
+ */
+export type ApplyContextFrame =
+  | {kind: 'remote'; source: 'patches' | 'update-value' | 'initial-sync'}
+  | {kind: 'undo'}
+  | {kind: 'redo'}
+  | {kind: 'normalization'}
+
+/**
+ * Reduces the frame stack to an `OperationOrigin` by fixed precedence
+ * (remote > undo > redo > normalization > local), regardless of nesting
+ * order.
+ */
+export function getOrigin(
+  frames: ReadonlyArray<ApplyContextFrame>,
+): OperationOrigin {
+  if (frames.some((frame) => frame.kind === 'remote')) {
+    return 'remote'
+  }
+  if (frames.some((frame) => frame.kind === 'undo')) {
+    return 'undo'
+  }
+  if (frames.some((frame) => frame.kind === 'redo')) {
+    return 'redo'
+  }
+  if (frames.some((frame) => frame.kind === 'normalization')) {
+    return 'normalization'
+  }
+  return 'local'
+}

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -10,6 +10,14 @@ import {withRemoteChanges} from '../../engine-plugins/engine-plugin.remote-chang
 import {pluginUndoing} from '../../engine-plugins/engine-plugin.undoing'
 import {pluginWithoutHistory} from '../../engine-plugins/engine-plugin.without-history'
 import {withoutPatching} from '../../engine-plugins/engine-plugin.without-patching'
+import {buildIndexMaps} from '../../internal-utils/build-index-maps'
+import {selectOperationImplementation} from '../../operations/operation.select'
+import {defineContainer, type Container} from '../../renderers/renderer.types'
+import {
+  resolveContainers,
+  resolveContainersRich,
+} from '../../schema/resolve-containers-batch'
+import type {PortableTextEditorEngine} from '../../types/editor-engine'
 import {createEditor} from '../create-editor'
 import type {Editor} from '../interfaces/editor'
 import type {EngineOperation} from '../interfaces/operation'
@@ -301,13 +309,13 @@ describe('operation channel', () => {
 
     editor.apply(insertTextOperation)
 
-    editor.isProcessingRemoteChanges = true
-    editor.apply({...insertTextOperation, offset: 0})
-    editor.isProcessingRemoteChanges = false
+    withRemoteChanges(editor, 'patches', () => {
+      editor.apply({...insertTextOperation, offset: 0})
+    })
 
-    editor.isUndoing = true
-    editor.apply({...insertTextOperation, offset: 0})
-    editor.isUndoing = false
+    pluginUndoing(editor, () => {
+      editor.apply({...insertTextOperation, offset: 0})
+    })
 
     expect(origins).toEqual(['local', 'remote', 'undo'])
   })
@@ -351,6 +359,204 @@ describe('operation channel', () => {
     ])
   })
 
+  test('a normalization bracket nested inside a consumer `normalizeNode` override does not clobber the outer bracket', () => {
+    const editor = createBareEditor(createDefaultValue())
+    const events: Array<{
+      origin: OperationEvent['origin']
+      isNormalizingNode: boolean
+    }> = []
+
+    let fixApplied = false
+    editor.normalizeNode = () => {
+      if (fixApplied) {
+        return
+      }
+      fixApplied = true
+
+      // Mirrors the inner bracket `operation.select`'s container repair
+      // establishes around its own `normalizeNode` call, nested inside
+      // this (outer) bracket.
+      const prev = editor.isNormalizingNode
+      editor.isNormalizingNode = true
+      editor.applyContext.push({kind: 'normalization'})
+      try {
+        // The inner bracket's own `normalizeNode` call.
+      } finally {
+        editor.applyContext.pop()
+        editor.isNormalizingNode = prev
+      }
+
+      editor.apply(insertTextOperation)
+    }
+
+    subscribeToOperations(editor, (event) => {
+      events.push({
+        origin: event.origin,
+        isNormalizingNode: event.isNormalizingNode,
+      })
+    })
+
+    editor.apply({
+      type: 'set',
+      path: [{_key: 'b1'}, 'style'],
+      value: 'h1',
+    })
+
+    expect(events).toEqual([
+      {origin: 'normalization', isNormalizingNode: true},
+      {origin: 'local', isNormalizingNode: false},
+    ])
+  })
+
+  test('an `operation.select` container-repair bracket nested inside a consumer `normalizeNode` override does not clobber the outer bracket', () => {
+    const schema = compileSchema(
+      defineSchema({
+        blockObjects: [
+          {
+            name: 'sidebar',
+            fields: [
+              {
+                name: 'markDefs',
+                type: 'array',
+                of: [
+                  {
+                    type: 'object',
+                    name: 'note',
+                    fields: [{name: 'title', type: 'string'}],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }),
+    )
+    const publicContainers: Array<Container> = [
+      defineContainer({type: 'sidebar', arrayField: 'markDefs'}),
+    ]
+    const value: Array<PortableTextBlock> = [
+      ...createDefaultValue(),
+      {_key: 'c1', _type: 'sidebar', markDefs: []},
+    ]
+    const editor = createBareEditor(value)
+    const containers = resolveContainers(schema, publicContainers)
+    buildIndexMaps(
+      {schema, containers, value},
+      {blockIndexMap: editor.blockIndexMap},
+    )
+    editor.containers = resolveContainersRich(schema, publicContainers)
+    editor.snapshot.context.schema = schema
+    editor.snapshot.context.containers = containers
+
+    const events: Array<{
+      operationType: string
+      origin: OperationEvent['origin']
+      isNormalizingNode: boolean
+    }> = []
+    subscribeToOperations(editor, (event) => {
+      events.push({
+        operationType: event.operation.type,
+        origin: event.origin,
+        isNormalizingNode: event.isNormalizingNode,
+      })
+    })
+
+    const containerPoint = {path: [{_key: 'c1'}], offset: 0}
+    let outerFired = false
+    editor.normalizeNode = () => {
+      if (outerFired) {
+        // The nested call `operation.select`'s repair issues for the
+        // empty container; nothing to fix.
+        return
+      }
+      outerFired = true
+
+      // Selecting the empty container lands the point on the container
+      // itself (it has no children to descend into), which is exactly
+      // the scenario `operation.select`'s container-repair bracket
+      // guards: it re-enters `editor.normalizeNode` nested inside this
+      // (outer) normalization bracket.
+      selectOperationImplementation({
+        snapshot: editor.snapshot,
+        operation: {
+          type: 'select',
+          editor: editor as unknown as PortableTextEditorEngine,
+          at: {anchor: containerPoint, focus: containerPoint},
+        },
+      })
+
+      editor.apply(insertTextOperation)
+    }
+
+    editor.apply({
+      type: 'set',
+      path: [{_key: 'b1'}, 'style'],
+      value: 'h1',
+    })
+
+    const insertTextEvent = events.find(
+      (event) => event.operationType === 'insert.text',
+    )
+    expect(insertTextEvent).toEqual({
+      operationType: 'insert.text',
+      origin: 'normalization',
+      isNormalizingNode: true,
+    })
+  })
+
+  test('`context` carries the frame stack `origin` derives from, across nested attribution brackets', () => {
+    const editor = createBareEditor(createDefaultValue())
+    const events: Array<{
+      origin: OperationEvent['origin']
+      context: OperationEvent['context']
+    }> = []
+
+    let fixApplied = false
+    editor.normalizeNode = () => {
+      if (!fixApplied) {
+        fixApplied = true
+        editor.apply(insertTextOperation)
+      }
+    }
+
+    subscribeToOperations(editor, (event) => {
+      events.push({origin: event.origin, context: event.context})
+    })
+
+    const setStyle = (value: string) => ({
+      type: 'set' as const,
+      path: [{_key: 'b1'}, 'style'],
+      value,
+    })
+
+    editor.apply(setStyle('h1'))
+
+    fixApplied = false
+    withRemoteChanges(editor, 'patches', () => {
+      editor.apply(setStyle('normal'))
+    })
+
+    fixApplied = false
+    pluginUndoing(editor, () => {
+      editor.apply(setStyle('h1'))
+    })
+
+    expect(events).toEqual([
+      {origin: 'normalization', context: [{kind: 'normalization'}]},
+      {origin: 'local', context: []},
+      {
+        origin: 'remote',
+        context: [{kind: 'remote', source: 'patches'}, {kind: 'normalization'}],
+      },
+      {origin: 'remote', context: [{kind: 'remote', source: 'patches'}]},
+      {
+        origin: 'undo',
+        context: [{kind: 'undo'}, {kind: 'normalization'}],
+      },
+      {origin: 'undo', context: [{kind: 'undo'}]},
+    ])
+  })
+
   test('a throw inside `withRemoteChanges` does not stick `isProcessingRemoteChanges`', () => {
     const editor = createBareEditor(createDefaultValue())
     editor.isProcessingRemoteChanges = false
@@ -361,12 +567,13 @@ describe('operation channel', () => {
     })
 
     expect(() =>
-      withRemoteChanges(editor, () => {
+      withRemoteChanges(editor, 'patches', () => {
         throw new Error('boom')
       }),
     ).toThrow('boom')
 
     expect(editor.isProcessingRemoteChanges).toEqual(false)
+    expect(editor.applyContext).toEqual([])
 
     editor.apply(insertTextOperation)
 
@@ -427,5 +634,24 @@ describe('operation channel', () => {
     }).toThrow('boom')
 
     expect(editor.isUndoing).toEqual(false)
+  })
+
+  test('a throw inside a normalization bracket leaves `isNormalizingNode` restored and `applyContext` balanced', () => {
+    const editor = createBareEditor(createDefaultValue())
+    editor.isNormalizingNode = false
+    editor.normalizeNode = () => {
+      throw new Error('boom')
+    }
+
+    expect(() =>
+      editor.apply({
+        type: 'set',
+        path: [{_key: 'b1'}, 'style'],
+        value: 'h1',
+      }),
+    ).toThrow('boom')
+
+    expect(editor.isNormalizingNode).toEqual(false)
+    expect(editor.applyContext).toEqual([])
   })
 })

--- a/packages/editor/src/engine/core/operation-channel.ts
+++ b/packages/editor/src/engine/core/operation-channel.ts
@@ -2,6 +2,7 @@ import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSelection} from '../../types/editor'
 import type {Editor} from '../interfaces/editor'
 import type {EngineOperation} from '../interfaces/operation'
+import {getOrigin, type ApplyContextFrame} from './apply-context'
 
 /**
  * The operation channel is the single place to observe every `EngineOperation` the
@@ -56,9 +57,14 @@ export type OperationEvent = {
   withHistory: boolean
   undoStepId: string | undefined
   /**
-   * Derived from the engine flags above, for declarative filtering.
+   * Derived from `applyContext`, for declarative filtering.
    */
   origin: OperationOrigin
+  /**
+   * A frozen snapshot of `editor.applyContext` at apply entry: the frame
+   * stack `origin` was derived from.
+   */
+  context: ReadonlyArray<ApplyContextFrame>
 }
 
 export type OperationListener = (event: OperationEvent) => void
@@ -122,15 +128,8 @@ export function createOperationEvent(
     isRedoing,
     withHistory: Boolean(editor.withHistory),
     undoStepId: editor.undoStepId,
-    origin: isProcessingRemoteChanges
-      ? 'remote'
-      : isUndoing
-        ? 'undo'
-        : isRedoing
-          ? 'redo'
-          : isNormalizingNode
-            ? 'normalization'
-            : 'local',
+    origin: getOrigin(editor.applyContext),
+    context: Object.freeze([...editor.applyContext]),
   }
 }
 

--- a/packages/editor/src/engine/create-editor.ts
+++ b/packages/editor/src/engine/create-editor.ts
@@ -19,6 +19,7 @@ export const createEditor = (): Editor => {
   /* eslint-disable @typescript-eslint/no-explicit-any */
   const e: any = {
     [EDITOR_BRAND]: true,
+    applyContext: [],
     operations: [],
     operationListeners: {before: [], after: []},
     marks: null,

--- a/packages/editor/src/engine/editor/normalize.ts
+++ b/packages/editor/src/engine/editor/normalize.ts
@@ -76,9 +76,15 @@ export function normalize(
           isTextBlock({schema: editor.snapshot.context.schema}, entryNode) &&
           entryNode.children.length === 0
         ) {
+          const prev = editor.isNormalizingNode
           editor.isNormalizingNode = true
-          editor.normalizeNode([entry.node, entry.path], {operation})
-          editor.isNormalizingNode = false
+          editor.applyContext.push(Object.freeze({kind: 'normalization'}))
+          try {
+            editor.normalizeNode([entry.node, entry.path], {operation})
+          } finally {
+            editor.applyContext.pop()
+            editor.isNormalizingNode = prev
+          }
         }
       }
     }
@@ -103,15 +109,27 @@ export function normalize(
 
       // If the node doesn't exist in the tree, it does not need to be normalized.
       if (dirtyPath.length === 0) {
+        const prev = editor.isNormalizingNode
         editor.isNormalizingNode = true
-        editor.normalizeNode([editor, dirtyPath], {operation})
-        editor.isNormalizingNode = false
+        editor.applyContext.push(Object.freeze({kind: 'normalization'}))
+        try {
+          editor.normalizeNode([editor, dirtyPath], {operation})
+        } finally {
+          editor.applyContext.pop()
+          editor.isNormalizingNode = prev
+        }
       } else if (hasNode(editor.snapshot, dirtyPath)) {
         const entry = getNode(editor.snapshot, dirtyPath)
         if (entry) {
+          const prev = editor.isNormalizingNode
           editor.isNormalizingNode = true
-          editor.normalizeNode([entry.node, entry.path], {operation})
-          editor.isNormalizingNode = false
+          editor.applyContext.push(Object.freeze({kind: 'normalization'}))
+          try {
+            editor.normalizeNode([entry.node, entry.path], {operation})
+          } finally {
+            editor.applyContext.pop()
+            editor.isNormalizingNode = prev
+          }
         }
       }
       iteration++

--- a/packages/editor/src/operations/operation.select.ts
+++ b/packages/editor/src/operations/operation.select.ts
@@ -37,9 +37,17 @@ export const selectOperationImplementation: OperationImplementation<
     if (containers.length > 0) {
       withoutNormalizing(operation.editor, () => {
         for (const entry of containers) {
+          const prev = operation.editor.isNormalizingNode
           operation.editor.isNormalizingNode = true
-          operation.editor.normalizeNode([entry.node, entry.path])
-          operation.editor.isNormalizingNode = false
+          operation.editor.applyContext.push(
+            Object.freeze({kind: 'normalization'}),
+          )
+          try {
+            operation.editor.normalizeNode([entry.node, entry.path])
+          } finally {
+            operation.editor.applyContext.pop()
+            operation.editor.isNormalizingNode = prev
+          }
         }
       })
       newSelection = resolveSelection(operation.editor, operation.at)

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -2,6 +2,7 @@ import type {Patch} from '@portabletext/patches'
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {EditorSnapshot} from '../editor/editor-snapshot'
 import type {DecoratedRange} from '../editor/range-decorations-machine'
+import type {ApplyContextFrame} from '../engine/core/apply-context'
 import type {DOMEditor} from '../engine/dom/plugin/dom-editor'
 import type {EngineOperation} from '../engine/interfaces/operation'
 import type {
@@ -34,6 +35,14 @@ export type RemotePatch = {
 export interface PortableTextEditorEngine extends DOMEditor {
   _key: 'editor'
   _type: 'editor'
+
+  /**
+   * The attribution bracket stack: pushed on entry and popped in `finally`
+   * by `withRemoteChanges`, `pluginUndoing`, `pluginRedoing`, and the
+   * normalization brackets. `getOrigin` (`engine/core/apply-context.ts`)
+   * reduces it to an `OperationOrigin`.
+   */
+  applyContext: Array<ApplyContextFrame>
 
   containers: ResolvedContainers
   annotations: Map<string, AnnotationConfig>


### PR DESCRIPTION
Second increment of replacing the change-attribution flag algebra with an explicit apply context (#3227 was the first). Attribution today is inferred from ambient booleans set by nested wrappers, and every gap in that algebra has surfaced as a reviewed bug on recent PRs. This introduces the replacement without migrating a single reader.

The engine gains `applyContext`, a discriminated-union frame stack: `{kind: 'remote', source}`, `{kind: 'undo'}`, `{kind: 'redo'}`, `{kind: 'normalization'}`, with local as the empty stack. Every attribution write site dual-writes, pushing a frozen frame beside the flag it already sets: the remote brackets state their source (`patches`, `initial-sync`, `update-value`), the undo/redo plugins push their kinds, and the four bare `isNormalizingNode` brackets push normalization frames. Flags stay authoritative for every reader except one: `createOperationEvent` derives `origin` from a fixed-precedence projection over the stack (remote > undo > redo > normalization > local), identical to the flag ternary it replaces, and snapshots the stack onto the event for future consumers.

Two deltas ride along at the bare `isNormalizingNode` sites, both deliberate: the flag now saves and restores `prev` in a `finally` instead of hard-clearing to `false`. Restore-to-prev keeps flag and stack aligned when brackets nest (a container repair inside a consumer `normalizeNode` override no longer clobbers the outer bracket, pinned red on the hard-clear), and the `finally` extends #3227's exception safety to the bare sites (pinned red without it). One tagging decision is pinned as deliberate rather than inherited: an editor created without an initial value has no initial sync, so its first real value is `update-value`.

The parity pins assert full `{origin, context}` values across the nesting combinations, and removing a frame push turns them red; the derivation switch itself is unfalsifiable under correct dual-write, which is the design working. Reader migration and flag deletion follow in the third increment, checked off against the parity inventory on the tracking ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core apply/attribution and sync paths; behavior is intended to stay parity with flags but nested normalization and remote tagging are easy to get wrong without the new tests.
> 
> **Overview**
> Introduces **`editor.applyContext`**, a nested stack of attribution frames (`remote` with source, `undo`, `redo`, `normalization`) that is **dual-written** alongside the existing boolean flags at every bracket entry site. Operation events now derive **`origin`** via **`getOrigin`** over that stack (same precedence as before) and expose a frozen **`context`** snapshot of the stack for subscribers.
> 
> **`withRemoteChanges`** now requires a **remote source** (`patches`, `initial-sync`, or `update-value`); remote patches use `patches`, and value sync threads **`initial-sync` vs `update-value`** (first real value on an editor with no initial value is **`update-value`**). Undo/redo and normalization paths push/pop matching frames; normalization brackets **restore** `isNormalizingNode` instead of clearing it so nested normalization (e.g. select container repair inside a custom `normalizeNode`) does not drop the outer attribution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc26d7335c7433f6bdecd2510f67f564a381582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->