### PR TITLE
refactor: rank normalization above remote in operation origin precedence

### DIFF
--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -2,6 +2,7 @@ import {compileSchema} from '@portabletext/schema'
 import {createActor} from 'xstate'
 import {coreConverters} from '../converters/converters.core'
 import type {Editor, EditorConfig} from '../editor'
+import {hasRemoteFrame} from '../engine/core/apply-context'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import type {EngineOperation} from '../engine/interfaces/operation'
 import {debug} from '../internal-utils/debug'
@@ -263,7 +264,7 @@ function createActors(config: {
       config.relay.send({
         type: 'operation',
         operation: event.operation,
-        origin: event.origin === 'remote' ? 'remote' : 'local',
+        origin: hasRemoteFrame(event.context) ? 'remote' : 'local',
       })
     })
   })

--- a/packages/editor/src/editor/range-decorations-machine.ts
+++ b/packages/editor/src/editor/range-decorations-machine.ts
@@ -7,10 +7,8 @@ import {
   type AnyEventObject,
   type CallbackLogicFunction,
 } from 'xstate'
-import {
-  subscribeToOperations,
-  type OperationOrigin,
-} from '../engine/core/operation-channel'
+import {hasRemoteFrame} from '../engine/core/apply-context'
+import {subscribeToOperations} from '../engine/core/operation-channel'
 import type {Node, NodeEntry} from '../engine/interfaces/node'
 import type {EngineOperation} from '../engine/interfaces/operation'
 import type {Range} from '../engine/interfaces/range'
@@ -31,7 +29,7 @@ const engineOperationCallback: CallbackLogicFunction<
   {
     type: 'engine operation'
     operation: EngineOperation
-    origin: OperationOrigin
+    origin: 'local' | 'remote'
   },
   {editorEngine: PortableTextEditorEngine}
 > = ({input, sendBack}) => {
@@ -46,7 +44,7 @@ const engineOperationCallback: CallbackLogicFunction<
         sendBack({
           type: 'engine operation',
           operation: event.operation,
-          origin: event.origin,
+          origin: hasRemoteFrame(event.context) ? 'remote' : 'local',
         })
       }
     },
@@ -95,7 +93,7 @@ export const rangeDecorationsMachine = setup({
       | {
           type: 'engine operation'
           operation: EngineOperation
-          origin: OperationOrigin
+          origin: 'local' | 'remote'
         }
       | {
           type: 'update read only'
@@ -175,7 +173,7 @@ export const rangeDecorationsMachine = setup({
           decoratedRange.rangeDecoration.onMoved?.({
             newSelection: null,
             rangeDecoration: decoratedRange.rangeDecoration,
-            origin: event.origin === 'remote' ? 'remote' : 'local',
+            origin: event.origin,
           })
           continue
         }
@@ -193,7 +191,7 @@ export const rangeDecorationsMachine = setup({
           decoratedRange.rangeDecoration.onMoved?.({
             newSelection: newRange,
             rangeDecoration: decoratedRange.rangeDecoration,
-            origin: event.origin === 'remote' ? 'remote' : 'local',
+            origin: event.origin,
           })
         }
 

--- a/packages/editor/src/editor/subscriber.history.ts
+++ b/packages/editor/src/editor/subscriber.history.ts
@@ -4,7 +4,7 @@
  */
 
 import type {PortableTextBlock} from '@portabletext/schema'
-import {isInNormalization} from '../engine/core/apply-context'
+import {hasRemoteFrame, isInNormalization} from '../engine/core/apply-context'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
@@ -70,9 +70,7 @@ export function subscribeHistory({
       return
     }
 
-    if (event.origin === 'remote') {
-      // We don't want to run any side effects when the editor is processing
-      // remote changes.
+    if (hasRemoteFrame(event.context)) {
       return
     }
 

--- a/packages/editor/src/engine-plugins/engine-plugin.performing-behavior-operation.ts
+++ b/packages/editor/src/engine-plugins/engine-plugin.performing-behavior-operation.ts
@@ -8,7 +8,9 @@ export function withPerformingBehaviorOperation(
 
   editor.isPerformingBehaviorOperation = true
 
-  fn()
-
-  editor.isPerformingBehaviorOperation = prev
+  try {
+    fn()
+  } finally {
+    editor.isPerformingBehaviorOperation = prev
+  }
 }

--- a/packages/editor/src/engine/core/apply-context.ts
+++ b/packages/editor/src/engine/core/apply-context.ts
@@ -15,15 +15,16 @@ export type ApplyContextFrame =
 
 /**
  * Reduces the frame stack to an `OperationOrigin` by fixed precedence
- * (remote > undo > redo > normalization > local), regardless of nesting
- * order.
+ * (undo > redo > normalization > remote > local), regardless of nesting
+ * order. Normalization outranks remote so a fix that runs while replaying
+ * a remote patch is attributed to the fix, not laundered into looking like
+ * an ordinary remote write; `hasRemoteFrame` is the precedence-blind read
+ * for callers that need the externally-triggered fact regardless of
+ * whether a fix ran on top of it.
  */
 export function getOrigin(
   frames: ReadonlyArray<ApplyContextFrame>,
 ): OperationOrigin {
-  if (frames.some((frame) => frame.kind === 'remote')) {
-    return 'remote'
-  }
   if (frames.some((frame) => frame.kind === 'undo')) {
     return 'undo'
   }
@@ -32,6 +33,9 @@ export function getOrigin(
   }
   if (frames.some((frame) => frame.kind === 'normalization')) {
     return 'normalization'
+  }
+  if (frames.some((frame) => frame.kind === 'remote')) {
+    return 'remote'
   }
   return 'local'
 }
@@ -52,7 +56,7 @@ export function hasRemoteFrame(
 
 /**
  * Precedence-blind: true whenever a `normalization` frame is on the stack,
- * even when a `remote` or `undo` frame outranks it in `getOrigin`.
+ * even when an `undo` or `redo` frame outranks it in `getOrigin`.
  */
 export function isInNormalization(
   frames: ReadonlyArray<ApplyContextFrame>,

--- a/packages/editor/src/engine/core/operation-channel.test.ts
+++ b/packages/editor/src/engine/core/operation-channel.test.ts
@@ -543,7 +543,7 @@ describe('operation channel', () => {
       {origin: 'normalization', context: [{kind: 'normalization'}]},
       {origin: 'local', context: []},
       {
-        origin: 'remote',
+        origin: 'normalization',
         context: [{kind: 'remote', source: 'patches'}, {kind: 'normalization'}],
       },
       {origin: 'remote', context: [{kind: 'remote', source: 'patches'}]},

--- a/packages/editor/tests/event.history.undo.test.tsx
+++ b/packages/editor/tests/event.history.undo.test.tsx
@@ -966,4 +966,66 @@ describe('event.history.undo', () => {
       expect(toTextspec(editor.getSnapshot().context)).toEqual('B: |')
     })
   })
+
+  test('Scenario: Remote-fallout normalization is not undoable', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const initialBlock = {
+      _type: 'block',
+      _key: blockKey,
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+    }
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      initialValue: [initialBlock],
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+    })
+
+    // A remote insert lands a second span with the same key as the first,
+    // firing the engine's duplicate-key fix during remote processing. The
+    // fix reports `origin: 'normalization'`, not `'remote'`, so the
+    // history subscriber must skip it by the remote frame on the operation
+    // event, or the remote-triggered `set` becomes a local undo step.
+    const duplicateSpan = {
+      _type: 'span',
+      _key: spanKey,
+      text: 'bar',
+      marks: ['strong'],
+    }
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [duplicateSpan],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [
+        {...initialBlock, children: [...initialBlock.children, duplicateSpan]},
+      ],
+    })
+
+    const repairedValue = [
+      {
+        ...initialBlock,
+        children: [initialBlock.children[0], {...duplicateSpan, _key: 'k4'}],
+      },
+    ]
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(repairedValue)
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(repairedValue)
+    })
+  })
 })

--- a/packages/editor/tests/range-decorations.test.tsx
+++ b/packages/editor/tests/range-decorations.test.tsx
@@ -713,6 +713,94 @@ describe('RangeDecorations', () => {
     })
   })
 
+  test('Scenario: A repair triggered by a remote patch reports a remote origin', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+      },
+    ]
+
+    const onMoved = vi.fn()
+
+    const rangeDecoration: RangeDecoration = {
+      component: (props) => (
+        <span data-testid="range-decoration">{props.children}</span>
+      ),
+      onMoved,
+      selection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      editableProps: {
+        rangeDecorations: [rangeDecoration],
+      },
+    })
+
+    await vi.waitFor(() =>
+      expect
+        .element(locator.getByTestId('range-decoration'))
+        .toBeInTheDocument(),
+    )
+
+    // The remote insert lands a second span with the same key as the
+    // first, so the engine's duplicate-key fix re-mints the duplicate.
+    // That repair is what moves the decoration, and it must report the
+    // origin of the change that triggered it: `remote`, not the repair's
+    // own executor.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [
+            {_type: 'span', _key: spanKey, text: 'bar', marks: ['strong']},
+          ],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(onMoved).toHaveBeenCalledTimes(1)
+    })
+
+    expect(onMoved.mock.calls[0]?.[0]).toEqual({
+      newSelection: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: 'k4'}],
+          offset: 1,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: 'k4'}],
+          offset: 3,
+        },
+      },
+      rangeDecoration,
+      origin: 'remote',
+    })
+  })
+
   test('Scenario: Undoing a local edit that moves a Range Decoration reports a local origin', async () => {
     const keyGenerator = createTestKeyGenerator()
     const blockKey = keyGenerator()


### PR DESCRIPTION
A normalization fix that runs while remote content is applied reports `origin: 'remote'`. That hides who made the change: a repair the local engine invented looks like an ordinary remote write. Upcoming work on how repair patches get published needs to tell these apart.

The fix: in `getOrigin`, `normalization` now outranks `remote`. A repair during remote processing reports `origin: 'normalization'`. Callers that need the "came from outside" fact read the frame stack directly via `hasRemoteFrame`.

Three readers relied on `remote` winning and had to migrate:

- `subscribeHistory` skipped remote changes via `event.origin === 'remote'`. Without migration, a remote-triggered repair would land in the local undo stack. Now checks `hasRemoteFrame`, pinned by a new test: a remote-triggered duplicate-key fix is not undoable.
- The public `operation` relay derived its `origin` from the reduced value. Now derives from the frame stack, so the documented contract holds: a fix reports the origin of the change that triggered it. Pinned by the existing origin suite, unmodified.
- The range-decorations machine mapped `onMoved`'s `origin` from the reduced value. Now derives from the frame stack, pinned by a new test: a remote-triggered repair that moves a decoration reports `remote`.

Each migration was proven load-bearing: revert it, keep the flip, watch its pin go red.

No public behavior changes, so no changeset. One rider: `withPerformingBehaviorOperation` now restores its flag in a `finally`, like its sibling wrappers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core operation-origin precedence and undo/history gating; behavior is preserved via explicit `hasRemoteFrame` migrations and new regression tests.
> 
> **Overview**
> **Operation attribution** now treats **normalization fixes above remote** in `getOrigin`, so repairs during remote patch replay report `origin: 'normalization'` instead of looking like ordinary remote writes. Callers that still need “externally triggered” use **`hasRemoteFrame`** on the apply-context stack.
> 
> **Migrated readers** so user-visible contracts stay the same: history skips undo steps when any remote frame is present (not only when `origin === 'remote'`); the public **`operation`** relay and range-decoration **`onMoved`** derive local vs remote from `hasRemoteFrame` rather than the reduced origin.
> 
> **`withPerformingBehaviorOperation`** resets `isPerformingBehaviorOperation` in a **`finally`** block if the wrapped callback throws.
> 
> New tests cover remote-triggered duplicate-key normalization: it must not become undoable, and decoration moves must still report **`remote`** origin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07b31194fe70ba8ac5f5935bd30813e423c9c793. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->