### PR TITLE
fix: remove the native `insertText` fast path

### DIFF
--- a/.changeset/remove-native-insert-fast-path.md
+++ b/.changeset/remove-native-insert-fast-path.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: remove the native `insertText` fast path
+
+Typing a character that a Behavior swallows no longer leaves the character visible in the editor: all text insertion now flows through the model, so a swallowed `insert.text` event never leaves a stray character stuck in the DOM.

--- a/packages/editor/src/engine/dom/utils/dom.ts
+++ b/packages/editor/src/engine/dom/utils/dom.ts
@@ -11,11 +11,6 @@ import {DOMEditor} from '../plugin/dom-editor'
 type DOMNode = globalThis.Node
 type DOMComment = globalThis.Comment
 type DOMElement = globalThis.Element
-// DOMText is used as a value (instanceof) in dom-editor.ts, so we need both
-// the type alias and a const reference to the global constructor.
-// oxlint-disable-next-line no-redeclare -- type and value live in separate TypeScript namespaces
-type DOMText = globalThis.Text
-const DOMText = globalThis.Text
 type DOMRange = globalThis.Range
 type DOMSelection = globalThis.Selection
 type DOMStaticRange = globalThis.StaticRange
@@ -23,7 +18,6 @@ type DOMStaticRange = globalThis.StaticRange
 export {
   type DOMNode,
   type DOMElement,
-  DOMText,
   type DOMRange,
   type DOMSelection,
   type DOMStaticRange,

--- a/packages/editor/src/engine/react/components/editable.tsx
+++ b/packages/editor/src/engine/react/components/editable.tsx
@@ -40,7 +40,6 @@ import {
   isPlainTextOnlyPaste,
   type DOMElement,
   type DOMRange,
-  type DOMText,
 } from '../../dom/utils/dom'
 import {
   CAN_USE_DOM,
@@ -80,8 +79,6 @@ import {useTrackUserInput} from '../hooks/use-track-user-input'
 import {debounce, throttle} from '../utils/debounce'
 import getDirection from '../utils/direction'
 import {RestoreDOM} from './restore-dom/restore-dom'
-
-type DeferredOperation = () => void
 
 const Children = (props: Parameters<typeof useChildren>[0]) => {
   const children = useChildren(props)
@@ -179,7 +176,6 @@ export const Editable = forwardRef(
     // Rerender editor when composition status changed
 
     const ref = useRef<HTMLDivElement | null>(null)
-    const deferredOperations = useRef<DeferredOperation[]>([])
     const processing = useRef(false)
 
     const {onUserInput, receivedUserInput} = useTrackUserInput()
@@ -681,76 +677,6 @@ export const Editable = forwardRef(
             return
           }
 
-          let native = false
-          if (
-            type === 'insertText' &&
-            selection &&
-            isCollapsedRange(selection) &&
-            // Only use native character insertion for single characters a-z or space for now.
-            // Long-press events (hold a + press 4 = ä) to choose a special character otherwise
-            // causes duplicate inserts.
-            event.data &&
-            event.data.length === 1 &&
-            /[a-z ]/i.test(event.data) &&
-            // Chrome has issues correctly editing the start of nodes: https://bugs.chromium.org/p/chromium/issues/detail?id=1249405
-            // When there is an inline element, e.g. a link, and you select
-            // right after it (the start of the next node).
-            selection.anchor.offset !== 0
-          ) {
-            native = true
-
-            // If the NODE_MAP is dirty, we can't trust the selection anchor (eg DOMEditor.toDOMPoint)
-            if (!editor.isNodeMapDirty) {
-              // Chrome also has issues correctly editing the end of anchor elements: https://bugs.chromium.org/p/chromium/issues/detail?id=1259100
-              // Therefore we don't allow native events to insert text at the end of anchor nodes.
-              const {anchor} = selection
-
-              const [node, offset] = DOMEditor.toDOMPoint(editor, anchor)
-              const anchorNode = node.parentElement?.closest('a')
-
-              const window = DOMEditor.getWindow(editor)
-
-              if (
-                native &&
-                anchorNode &&
-                DOMEditor.hasDOMNode(editor, anchorNode)
-              ) {
-                // Find the last text node inside the anchor.
-                const lastText = window?.document
-                  .createTreeWalker(anchorNode, NodeFilter.SHOW_TEXT)
-                  .lastChild() as DOMText | null
-
-                if (
-                  lastText === node &&
-                  lastText.textContent?.length === offset
-                ) {
-                  native = false
-                }
-              }
-
-              // Chrome has issues with the presence of tab characters inside elements with whiteSpace = 'pre'
-              // causing abnormal insert behavior: https://bugs.chromium.org/p/chromium/issues/detail?id=1219139
-              if (
-                native &&
-                node.parentElement &&
-                window?.getComputedStyle(node.parentElement)?.whiteSpace ===
-                  'pre'
-              ) {
-                const block = getParent(editor.snapshot, anchor.path, {
-                  match: (node) =>
-                    isTextBlock({schema: editor.snapshot.context.schema}, node),
-                })
-
-                if (block) {
-                  const blockText = getText(editor.snapshot, block.path)
-
-                  if (blockText?.includes('\t')) {
-                    native = false
-                  }
-                }
-              }
-            }
-          }
           // COMPAT: For the deleting forward/backward input types we don't want
           // to change the selection because it is the range that will be deleted,
           // and those commands determine that for themselves.
@@ -788,8 +714,6 @@ export const Editable = forwardRef(
               })
 
               if (range && (!selection || !rangeEquals(selection, range))) {
-                native = false
-
                 const selectionRef =
                   !isCompositionChange &&
                   editor.snapshot.context.selection &&
@@ -810,9 +734,7 @@ export const Editable = forwardRef(
             return
           }
 
-          if (!native) {
-            event.preventDefault()
-          }
+          event.preventDefault()
 
           // COMPAT: If the selection is expanded, even if the command seems like
           // a delete forward/backward command it should delete the selection.
@@ -976,23 +898,11 @@ export const Editable = forwardRef(
                   editor,
                 })
               } else if (typeof data === 'string') {
-                // Only insertText operations use the native functionality, for now.
-                // Potentially expand to single character deletes, as well.
-                if (native) {
-                  deferredOperations.current.push(() =>
-                    editorActor.send({
-                      type: 'behavior event',
-                      behaviorEvent: {type: 'insert.text', text: data},
-                      editor,
-                    }),
-                  )
-                } else {
-                  editorActor.send({
-                    type: 'behavior event',
-                    behaviorEvent: {type: 'insert.text', text: data},
-                    editor,
-                  })
-                }
+                editorActor.send({
+                  type: 'behavior event',
+                  behaviorEvent: {type: 'insert.text', text: data},
+                  editor,
+                })
               }
 
               break
@@ -1177,15 +1087,6 @@ export const Editable = forwardRef(
                     androidInputManagerRef.current.handleInput()
                     return
                   }
-
-                  // Flush native operations, as native events will have propogated
-                  // and we can correctly compare DOM text values in components
-                  // to stop rendering, so that browser functions like autocorrect
-                  // and spellcheck work as expected.
-                  for (const op of deferredOperations.current) {
-                    op()
-                  }
-                  deferredOperations.current = []
 
                   // COMPAT: Since `beforeinput` doesn't fully `preventDefault`,
                   // there's a chance that content might be placed in the browser's undo stack.

--- a/packages/editor/tests/behavior-api.test.tsx
+++ b/packages/editor/tests/behavior-api.test.tsx
@@ -370,6 +370,57 @@ describe('Behavior API', () => {
     })
   })
 
+  test('Scenario: A swallowed character never reaches the DOM', async () => {
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+      },
+    ]
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      initialValue,
+      children: (
+        <BehaviorPlugin
+          behaviors={[
+            defineBehavior({
+              on: 'insert.text',
+              guard: ({event}) => event.text === 'x',
+              actions: [],
+            }),
+          ]}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          offset: 3,
+        },
+      },
+    })
+    await userEvent.keyboard('x')
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+    expect(locator.element().textContent).toEqual('foo')
+  })
+
   test('Scenario: `forward` forwards an event to succeeding Behaviors', async () => {
     const {editor, locator} = await createTestEditor({
       children: (


### PR DESCRIPTION
Typing a character that a behavior swallows (`on: 'insert.text'` with empty `actions`) left the character visible in the editor: the model correctly stayed unchanged, but the DOM kept it. The cause is the native insertion fast path: for a single a-z/space character at a collapsed, nonzero-offset selection, `beforeinput` skipped `preventDefault`, the browser mutated the DOM directly, and the `insert.text` behavior event ran deferred on the following `input` event. When that deferred event changed nothing, no rerender happened, so the reconciling layout effect that would repair the DOM never ran. Upstream Slate has the same bug (their open fix compensates by deleting the stray character afterwards).

This removes the fast path instead: `insertText` now always prevents the default and sends `insert.text` synchronously, the route every other input already took (punctuation, digits, offset 0, IME, Android). The fast-path guards, the deferred-operation machinery, and a dead `DOMText` export go with it; the diff is net negative. Pinned by a browser test asserting a swallowed character reaches neither the model nor the DOM, red on the fast-path code.

The semantic delta worth scrutiny: previously-native keystrokes now render through the model. Typing latency measured at parity (40 keystrokes into a 300-block document, headless chromium, 3 runs: 193/236/204 ms with the fast path, 138/188/198 ms without). A deleted comment claimed the deferral kept autocorrect and spellcheck working; the full chromium (2042 tests) and firefox (2022) suites pass, but spellcheck interaction has no pinning test, so that path is verified only by suite coverage. WebKit did not run: the browser session fails to connect on this machine, reproduced on an untouched `main` checkout.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core text-input handling for all single-character typing; previously-native keystrokes now render only through the model, with spellcheck/autocorrect behavior verified only by existing suite coverage rather than a dedicated test.
> 
> **Overview**
> Removes the **native `insertText` fast path** so single-character typing no longer bypasses the editor model. **`beforeinput` for `insertText` always calls `preventDefault()`**, and **`insert.text` behavior events are sent synchronously** instead of being deferred until the next `input` event.
> 
> That fixes a bug where a Behavior that **swallows** `insert.text` (empty `actions`) left a **ghost character in the DOM** while the document model stayed correct—the browser had already inserted the character natively, and no rerender ran to reconcile.
> 
> Also **drops the deferred-operation queue**, the Chrome-specific guards (anchors, `pre` + tabs, a–z/space-only), and the unused **`DOMText` export**. A **browser test** asserts swallowed `x` never appears in the model or `textContent`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bda594d059fc649a667a7af3449c3f98b4bc6a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->