### PR TITLE
fix: schedule keyless children from a wholesale set for key-mint normalization

### DIFF
--- a/.changeset/mint-keys-for-unusable-keys.md
+++ b/.changeset/mint-keys-for-unusable-keys.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: mint keys for empty-string and non-string `_key` values, not just `undefined`
+
+A child carrying `_key: ''` or a non-string `_key` now gets a fresh key minted by normalization, the same repair a child with no `_key` at all already received. Previously such keys were kept as-is, leaving nodes the editor could not reliably address. When several keyless siblings arrive at once, each now receives its own distinct key instead of the first sibling absorbing every mint.

--- a/.changeset/schedule-keyless-children-normalization.md
+++ b/.changeset/schedule-keyless-children-normalization.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: schedule keyless children from a wholesale set for key-mint normalization
+
+Blocks or children that arrive without a `_key` through a whole-array `set` patch are now repaired: normalization mints a key for every keyless child and emits the corresponding `set` patches. Previously such children were skipped when collecting normalization work, so they stayed keyless in the editor and any edit addressing them could not target the document.

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -113,7 +113,7 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
   // Uses numeric index in the path because the node has no _key to
   // address it by. Any ancestor segments with undefined _key are also
   // resolved to numeric indices.
-  if (nodeRecord['_key'] === undefined && path.length > 0) {
+  if (!hasUsableKey(nodeRecord['_key']) && path.length > 0) {
     const newKey = editor.snapshot.context.keyGenerator()
     debug.normalization('Setting missing key on node')
 
@@ -122,7 +122,10 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     const numericPath: Path = []
     let currentNode: Node | undefined
 
-    for (const segment of path) {
+    for (let segmentIndex = 0; segmentIndex < path.length; segmentIndex++) {
+      const segment = path[segmentIndex]
+      const isLastSegment = segmentIndex === path.length - 1
+
       if (typeof segment === 'string') {
         // Field name: descend into the field
         if (currentNode) {
@@ -138,18 +141,39 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
           ] as ArrayLike<Node>) ?? [])
         : editor.snapshot.context.value
 
-      if (isKeyedSegment(segment) && segment._key !== undefined) {
+      if (isKeyedSegment(segment) && hasUsableKey(segment._key)) {
         numericPath.push(segment)
         currentNode = Array.prototype.find.call(
           siblings,
           (child: Node) => child._key === segment._key,
         )
       } else {
-        // Undefined _key or numeric: resolve to numeric index
+        // Unusable _key or numeric: resolve to numeric index.
+        // `getNode` canonicalizes every resolved segment to `{_key}`, so
+        // several keyless siblings all arrive here as the same
+        // indistinguishable segment. The last segment addresses `node`
+        // itself and resolves by reference; an ancestor segment resolves
+        // to the sibling whose subtree holds `node`. Only when neither
+        // identifies a sibling does the first-keyless scan apply.
         let index = typeof segment === 'number' ? segment : -1
+        if (index === -1 && isLastSegment) {
+          index = Array.prototype.indexOf.call(siblings, node)
+        }
+        if (index === -1 && !isLastSegment) {
+          for (let i = 0; i < siblings.length; i++) {
+            const sibling = siblings[i] as Node
+            if (
+              !hasUsableKey(sibling._key) &&
+              subtreeContainsNode(sibling, node)
+            ) {
+              index = i
+              break
+            }
+          }
+        }
         if (index === -1) {
           for (let i = 0; i < siblings.length; i++) {
-            if ((siblings[i] as Node)._key === undefined) {
+            if (!hasUsableKey((siblings[i] as Node)._key)) {
               index = i
               break
             }
@@ -650,4 +674,36 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     return
   }
+}
+
+/**
+ * A key only addresses a node when it's a non-empty string; sync payloads
+ * and hand-authored content can carry `undefined`, `null`, or `''`.
+ */
+function hasUsableKey(key: unknown): key is string {
+  return typeof key === 'string' && key !== ''
+}
+
+function subtreeContainsNode(candidate: object, node: object): boolean {
+  if (candidate === node) {
+    return true
+  }
+
+  for (const value of Object.values(candidate)) {
+    if (!Array.isArray(value)) {
+      continue
+    }
+
+    for (const child of value) {
+      if (
+        typeof child === 'object' &&
+        child !== null &&
+        subtreeContainsNode(child, node)
+      ) {
+        return true
+      }
+    }
+  }
+
+  return false
 }

--- a/packages/editor/src/paths/get-dirty-paths.test.ts
+++ b/packages/editor/src/paths/get-dirty-paths.test.ts
@@ -215,6 +215,40 @@ describe(getDirtyPaths.name, () => {
       ])
     })
 
+    test('root-level value replacement with keyless children dirties them by numeric index', () => {
+      const newValue: Array<Node> = [
+        {
+          _type: 'block',
+          _key: undefined as unknown as string,
+          children: [{_type: 'span', _key: 's1', text: 'foo'}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: '',
+          children: [{_type: 'span', _key: 's2', text: 'bar'}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ]
+
+      expect(
+        getDirtyPaths(
+          {
+            schema,
+            containers: emptyContainers,
+            value: [],
+          },
+          {
+            type: 'set',
+            path: [],
+            value: newValue,
+          },
+        ),
+      ).toEqual([[], [0], [0, 'children', 0], [1], [1, 'children', 0]])
+    })
+
     test('single property set dirties node path levels', () => {
       expect(
         getDirtyPaths(
@@ -315,6 +349,46 @@ describe(getDirtyPaths.name, () => {
         [{_key: 'b1'}],
         [{_key: 'b1'}, 'children', {_key: 'new-s1'}],
         [{_key: 'b1'}, 'children', {_key: 'new-s2'}],
+      ])
+    })
+
+    test('child array field replacement with keyless children dirties them by numeric index', () => {
+      const blockNode: Node = {
+        _type: 'block',
+        _key: 'b1',
+        children: [
+          {_type: 'span', _key: 's1', text: 'hello'},
+          {_type: 'span', _key: 's2', text: 'world'},
+        ],
+        markDefs: [],
+        style: 'normal',
+      }
+
+      expect(
+        getDirtyPaths(
+          {
+            schema,
+            containers: emptyContainers,
+            value: [blockNode],
+          },
+          {
+            type: 'set',
+            path: [{_key: 'b1'}, 'children'],
+            value: [
+              {
+                _type: 'span',
+                _key: undefined as unknown as string,
+                text: 'foo',
+              },
+              {_type: 'span', _key: '', text: 'bar'},
+            ],
+          },
+        ),
+      ).toEqual([
+        [],
+        [{_key: 'b1'}],
+        [{_key: 'b1'}, 'children', 0],
+        [{_key: 'b1'}, 'children', 1],
       ])
     })
 

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -101,16 +101,17 @@ export function getDirtyPaths(
         if (Array.isArray(op.value)) {
           for (let i = 0; i < op.value.length; i++) {
             const child = op.value[i]
-            if (
-              typeof child !== 'object' ||
-              child === null ||
-              !('_key' in child) ||
-              typeof child._key !== 'string'
-            ) {
+            if (typeof child !== 'object' || child === null) {
               continue
             }
             const childNode = child as Node
-            const childPath: Path = [{_key: childNode._key}]
+            const hasUsableKey =
+              '_key' in child &&
+              typeof child._key === 'string' &&
+              child._key !== ''
+            const childPath: Path = hasUsableKey
+              ? [{_key: childNode._key}]
+              : [i]
             levels.push(childPath)
             // Seed the walker with the child's own registration so it
             // can recurse into the child's container fields. At root,
@@ -198,16 +199,14 @@ export function getDirtyPaths(
               continue
             }
 
-            if (!('_key' in child) || typeof child._key !== 'string') {
-              continue
-            }
-
             const childNode = child as Node
-            const childPath: Path = [
-              ...nodePath,
-              propertyName,
-              {_key: childNode._key},
-            ]
+            const hasUsableKey =
+              '_key' in child &&
+              typeof child._key === 'string' &&
+              child._key !== ''
+            const childPath: Path = hasUsableKey
+              ? [...nodePath, propertyName, {_key: childNode._key}]
+              : [...nodePath, propertyName, i]
             levels.push(childPath)
             collectDescendantPaths(context, childNode, childPath, levels, seed)
           }

--- a/packages/editor/tests/normalization.test.tsx
+++ b/packages/editor/tests/normalization.test.tsx
@@ -355,6 +355,255 @@ describe('normalization', () => {
     })
   })
 
+  test('Scenario: keyless siblings from a wholesale children set each get a distinct minted key', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children'],
+          value: [
+            {_type: 'span', text: 'bar', marks: []},
+            {_type: 'span', text: 'baz', marks: []},
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: 'k5', text: 'bar', marks: []},
+            {_type: 'span', _key: 'k4', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', 1, '_key'],
+          value: 'k4',
+        },
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', 0, '_key'],
+          value: 'k5',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: keyless blocks with keyless children each get distinct minted keys', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // A root-level set delivers two keyless blocks, each holding a keyless
+    // span. The block segment of each span's dirty path is itself keyless,
+    // so resolving it by "first sibling without a key" would send both
+    // spans' mints into the first block.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [],
+          value: [
+            {
+              _type: 'block',
+              children: [{_type: 'span', text: 'bar', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+            {
+              _type: 'block',
+              children: [{_type: 'span', text: 'baz', marks: []}],
+              markDefs: [],
+              style: 'normal',
+            },
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k7',
+          children: [{_type: 'span', _key: 'k6', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k5',
+          children: [{_type: 'span', _key: 'k4', text: 'baz', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [1, 'children', 0, '_key'],
+          value: 'k4',
+        },
+        {
+          type: 'set',
+          path: [1, '_key'],
+          value: 'k5',
+        },
+        {
+          type: 'set',
+          path: [0, 'children', 0, '_key'],
+          value: 'k6',
+        },
+        {
+          type: 'set',
+          path: [0, '_key'],
+          value: 'k7',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: siblings with an empty-string or non-string `_key` each get a distinct minted key', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children'],
+          value: [
+            {_type: 'span', _key: '', text: 'bar', marks: []},
+            {
+              _type: 'span',
+              _key: 42 as unknown as string,
+              text: 'baz',
+              marks: [],
+            },
+          ],
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: 'k5', text: 'bar', marks: []},
+            {_type: 'span', _key: 'k4', text: 'baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(patches).toEqual([
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', 1, '_key'],
+          value: 'k4',
+        },
+        {
+          type: 'set',
+          path: [{_key: blockKey}, 'children', 0, '_key'],
+          value: 'k5',
+        },
+      ])
+    })
+  })
+
   test('Scenario: block with no `_key` gets a key via numeric index', async () => {
     const patches: Array<Patch> = []
     const keyGenerator = createTestKeyGenerator()


### PR DESCRIPTION
A child that arrives without a usable `_key` gets stuck: the editor cannot address it, so edits inside it never reach the document. The engine has a normalization rule that mints missing keys, but two gaps starve it.

1. **Keyless children were never scheduled.** Dirty-path collection skipped children of a whole-array `set` when `_key` was not a string, so the mint rule never saw them. They are now scheduled by numeric index. Pinned by unit tests and a browser test: a `children` set with two keyless siblings ends with distinct minted keys (red before: no keys minted at all).

2. **The rule only fired on `undefined`.** `_key: ''` and non-string keys were kept as-is. The trigger is now "not a usable key". Fixing this exposed a latent ambiguity: several keyless siblings collapse into the same `{_key: undefined}` path segment, so every mint landed on the first keyless sibling. The node being normalized now resolves by object reference, and a keyless ancestor segment resolves to the sibling whose subtree contains that node. Pinned by two browser tests: keyless siblings in one block, and keyless blocks each holding a keyless child (red before: the second block's child stayed keyless).

Both fixes are consumer-observable and ship changesets. Each was proven red-on-old in isolation. Full unit and chromium suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core patch application, dirty-path collection, and normalization addressing—document identity and edit targeting—but changes are narrowly scoped to malformed/missing keys with strong test coverage.
> 
> **Overview**
> Fixes cases where Portable Text nodes with missing or invalid `_key` values never got keys minted, so the editor could not target them for edits.
> 
> **Dirty-path scheduling:** Whole-array `set` patches (root document or a child array like `children`) now mark keyless or unusable-key children using **numeric indices** instead of skipping them, so key-mint normalization actually runs.
> 
> **Key-mint rule:** Normalization treats a key as usable only when it is a **non-empty string**; `undefined`, `''`, and non-string `_key` values are repaired like missing keys. Path resolution for applying `_key` sets no longer collapses multiple keyless siblings onto the first match—it uses object reference for the target node and subtree matching for keyless ancestor segments so **each sibling gets its own minted key**.
> 
> Covered by new unit tests on `getDirtyPaths` and integration scenarios in `normalization.test.tsx`; ships as two patch changesets for `@portabletext/editor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ac1ee824448c68e99e1dc7b15aacf0133b9549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->