### PR TITLE
fix: keep numeric path segments for keyless nodes in resolved paths

### DIFF
--- a/.changeset/keyless-numeric-path-segments.md
+++ b/.changeset/keyless-numeric-path-segments.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: keep numeric path segments for keyless nodes in resolved paths
+
+Paths returned by `getNode`, `getChildren`, and `getAncestors` now carry the numeric sibling index for a node without a usable `_key`, instead of a fabricated `{_key: undefined}` segment that cannot distinguish keyless siblings. Repairs and edits addressing keyless nodes now always target the right node, including keyless children nested under keyless parents, and the patches they emit address the same numeric position.

--- a/packages/editor/src/engine/core/apply-operation.ts
+++ b/packages/editor/src/engine/core/apply-operation.ts
@@ -670,11 +670,12 @@ function resolveChildIndex(
 }
 
 /**
- * Extract the block key from the first segment of a path.
+ * Extract the root block reference from the first segment of a path:
+ * keyed, or a numeric index for a node normalization has not keyed yet.
  */
-function findBlockSegment(path: Path): KeyedSegment | undefined {
+function findBlockSegment(path: Path): KeyedSegment | number | undefined {
   const firstSegment = path[0]
-  if (isKeyedSegment(firstSegment)) {
+  if (isKeyedSegment(firstSegment) || typeof firstSegment === 'number') {
     return firstSegment
   }
   return undefined
@@ -684,8 +685,14 @@ function findBlockSegment(path: Path): KeyedSegment | undefined {
  * Resolve a root block's index via `blockIndexMap`, falling back to a
  * linear scan when the map misses or disagrees with the tree.
  */
-function resolveBlockIndex(editor: Editor, segment: KeyedSegment): number {
+function resolveBlockIndex(
+  editor: Editor,
+  segment: KeyedSegment | number,
+): number {
   const value = editor.snapshot.context.value
+  if (typeof segment === 'number') {
+    return segment < value.length ? segment : -1
+  }
   const index = editor.blockIndexMap.get(serializePath([segment]))
   if (index !== undefined && value[index]?._key === segment._key) {
     return index

--- a/packages/editor/src/engine/core/normalize-node.ts
+++ b/packages/editor/src/engine/core/normalize-node.ts
@@ -11,6 +11,7 @@ import {createPlaceholderBlock} from '../../internal-utils/create-placeholder-bl
 import {debug} from '../../internal-utils/debug'
 import {isEqualMarkDefs} from '../../internal-utils/equality'
 import {getChildFieldName} from '../../paths/get-child-field-name'
+import {hasUsableKey} from '../../paths/node-segment'
 import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerByPath} from '../../schema/resolve-container-by-path'
 import {getChildren} from '../../traversal/get-children'
@@ -19,7 +20,6 @@ import {getParent} from '../../traversal/get-parent'
 import {getPathSubSchema} from '../../traversal/get-path-sub-schema'
 import {getTextBlock} from '../../traversal/get-text-block'
 import {isObject} from '../../traversal/is-object'
-import {isKeyedSegment} from '../../utils/util.is-keyed-segment'
 import {isEditor} from '../editor/is-editor'
 import type {Editor} from '../interfaces/editor'
 import type {Node} from '../interfaces/node'
@@ -109,88 +109,19 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
     return
   }
 
-  // Set missing _key on any non-editor node.
-  // Uses numeric index in the path because the node has no _key to
-  // address it by. Any ancestor segments with undefined _key are also
-  // resolved to numeric indices.
+  // Set missing _key on any non-editor node. The resolved path already
+  // identifies the node: keyed segments where keys exist, numeric
+  // indices where they don't (see `nodeSegment`), so the `set` applies
+  // to it as-is.
   if (!hasUsableKey(nodeRecord['_key']) && path.length > 0) {
     const newKey = editor.snapshot.context.keyGenerator()
     debug.normalization('Setting missing key on node')
 
-    // Build a fully resolved path by walking the tree from the root,
-    // replacing any undefined keyed segments with numeric indices.
-    const numericPath: Path = []
-    let currentNode: Node | undefined
-
-    for (let segmentIndex = 0; segmentIndex < path.length; segmentIndex++) {
-      const segment = path[segmentIndex]
-      const isLastSegment = segmentIndex === path.length - 1
-
-      if (typeof segment === 'string') {
-        // Field name: descend into the field
-        if (currentNode) {
-          numericPath.push(segment)
-        }
-        continue
-      }
-
-      // Determine the siblings array at this level
-      const siblings: ArrayLike<Node> = currentNode
-        ? (((currentNode as Record<string, unknown>)[
-            numericPath[numericPath.length - 1] as string
-          ] as ArrayLike<Node>) ?? [])
-        : editor.snapshot.context.value
-
-      if (isKeyedSegment(segment) && hasUsableKey(segment._key)) {
-        numericPath.push(segment)
-        currentNode = Array.prototype.find.call(
-          siblings,
-          (child: Node) => child._key === segment._key,
-        )
-      } else {
-        // Unusable _key or numeric: resolve to numeric index.
-        // `getNode` canonicalizes every resolved segment to `{_key}`, so
-        // several keyless siblings all arrive here as the same
-        // indistinguishable segment. The last segment addresses `node`
-        // itself and resolves by reference; an ancestor segment resolves
-        // to the sibling whose subtree holds `node`. Only when neither
-        // identifies a sibling does the first-keyless scan apply.
-        let index = typeof segment === 'number' ? segment : -1
-        if (index === -1 && isLastSegment) {
-          index = Array.prototype.indexOf.call(siblings, node)
-        }
-        if (index === -1 && !isLastSegment) {
-          for (let i = 0; i < siblings.length; i++) {
-            const sibling = siblings[i] as Node
-            if (
-              !hasUsableKey(sibling._key) &&
-              subtreeContainsNode(sibling, node)
-            ) {
-              index = i
-              break
-            }
-          }
-        }
-        if (index === -1) {
-          for (let i = 0; i < siblings.length; i++) {
-            if (!hasUsableKey((siblings[i] as Node)._key)) {
-              index = i
-              break
-            }
-          }
-        }
-        if (index !== -1) {
-          numericPath.push(index)
-          currentNode = siblings[index] as Node
-        }
-      }
-    }
-
     editor.apply({
       type: 'set',
-      path: [...numericPath, '_key'],
+      path: [...path, '_key'],
       value: newKey,
-      inverse: {type: 'unset', path: [...numericPath, '_key']},
+      inverse: {type: 'unset', path: [...path, '_key']},
     })
     return
   }
@@ -674,36 +605,4 @@ export const normalizeNode: WithEditorFirstArg<Editor['normalizeNode']> = (
 
     return
   }
-}
-
-/**
- * A key only addresses a node when it's a non-empty string; sync payloads
- * and hand-authored content can carry `undefined`, `null`, or `''`.
- */
-function hasUsableKey(key: unknown): key is string {
-  return typeof key === 'string' && key !== ''
-}
-
-function subtreeContainsNode(candidate: object, node: object): boolean {
-  if (candidate === node) {
-    return true
-  }
-
-  for (const value of Object.values(candidate)) {
-    if (!Array.isArray(value)) {
-      continue
-    }
-
-    for (const child of value) {
-      if (
-        typeof child === 'object' &&
-        child !== null &&
-        subtreeContainsNode(child, node)
-      ) {
-        return true
-      }
-    }
-  }
-
-  return false
 }

--- a/packages/editor/src/engine/utils/modify.ts
+++ b/packages/editor/src/engine/utils/modify.ts
@@ -4,7 +4,6 @@ import {
   type PortableTextBlock,
   type PortableTextSpan,
 } from '@portabletext/schema'
-import {serializePath} from '../../paths/serialize-path'
 import {resolveContainerAt} from '../../schema/resolve-container-at'
 import {getNodeChildren} from '../../traversal/get-children'
 import {getNode} from '../../traversal/get-node'
@@ -37,20 +36,6 @@ function replaceChildren<T>(
 export const removeChildren = replaceChildren
 
 /**
- * Find the index of a node in an array by its _key.
- */
-function findIndexByKey(children: Array<Node>, key: string): number {
-  return children.findIndex((child) => child._key === key)
-}
-
-/**
- * Extract the keyed segments from a path (skipping field name strings).
- */
-function getKeyedSegments(path: Path): Array<{_key: string}> {
-  return path.filter(isKeyedSegment)
-}
-
-/**
  * Replace a descendant with a new node, replacing all ancestors
  */
 export const modifyDescendant = <N extends Node>(
@@ -70,135 +55,91 @@ export const modifyDescendant = <N extends Node>(
   if (!nodeEntry) {
     return
   }
-  const node = nodeEntry.node
-  let modifiedNode: Node = f(node as N)
 
-  // Walk down from the root to collect the child field name at each level.
-  // This is needed to rebuild ancestors using the correct field (e.g. 'rows',
-  // 'cells', 'content') instead of always assuming 'children'.
-  // Use the resolved path from getNode which converts numeric segments to keyed.
-  // Also track original numeric indices for segments that were numeric in the input path,
-  // since keyed lookup is ambiguous for duplicate keys.
-  const keyedSegments = getKeyedSegments(nodeEntry.path)
-  const numericIndices = new Map<number, number>()
-  {
-    let keyedIdx = 0
-    for (const segment of path) {
-      if (typeof segment === 'number') {
-        numericIndices.set(keyedIdx, segment)
-        keyedIdx++
-      } else if (isKeyedSegment(segment)) {
-        keyedIdx++
-      }
-    }
+  // One ordered node-segment list per path: keyed segments identify
+  // siblings by `_key`, numeric segments by index (resolved paths carry
+  // numbers for nodes normalization has not keyed yet). The input path's
+  // numeric segments win over resolved keyed lookups: with duplicate
+  // keys, a keyed lookup finds the first match regardless of which
+  // sibling the caller addressed.
+  const resolvedNodeSegments = nodeEntry.path.filter(
+    (segment) => typeof segment !== 'string',
+  )
+  const inputNodeSegments = path.filter(
+    (segment) => typeof segment !== 'string',
+  )
+
+  // Walk down once, capturing at each level the parent's child array,
+  // its field name, and the child's concrete index. The captures are
+  // everything the bottom-up rebuild needs; no re-resolution against a
+  // value that is about to change.
+  const levels: Array<{
+    parentNode: Node | {value: Array<Node>}
+    fieldName: string
+    children: Array<Node>
+    index: number
+  }> = []
+  let currentNode: Node | {value: Array<Node>} = {
+    value: editor.snapshot.context.value,
   }
-  const fieldNames: string[] = []
-  {
-    let currentNode: Node | {value: Array<Node>} = {
-      value: editor.snapshot.context.value,
-    }
-    let currentParent:
-      | import('../../schema/resolve-containers').RegisteredContainer
-      | undefined
+  let currentParent:
+    | import('../../schema/resolve-containers').RegisteredContainer
+    | undefined
 
-    for (let i = 0; i < keyedSegments.length; i++) {
-      const result = getNodeChildren(context, currentNode, currentParent)
-      if (!result) {
-        return
-      }
-      fieldNames.push(result.fieldName)
-      // Use numeric index when available (handles duplicate keys where
-      // keyed lookup would find the wrong sibling).
-      const numericIndex = numericIndices.get(i)
-      const child =
-        numericIndex !== undefined
-          ? result.children[numericIndex]
-          : result.children.find((c) => c._key === keyedSegments[i]!._key)
-      if (!child) {
-        return
-      }
-      currentNode = child
-      currentParent = result.parent
-    }
-  }
-
-  // Rebuild ancestors from the target node back up to the root.
-  // keyedSegments[0] is the top-level block, keyedSegments[last] is the target.
-  // We walk backwards, replacing each ancestor's child with the modified node.
-  for (let level = keyedSegments.length - 2; level >= 0; level--) {
-    const childKey = keyedSegments[level + 1]!._key
-    const fieldName = fieldNames[level + 1]!
-
-    // Build ancestor path from the original path by finding the segment
-    // at the given keyed level. We count non-string segments to map from
-    // keyed level to original path index.
-    let ancestorPathEnd = -1
-    let keyedCount = 0
-    for (let pi = 0; pi < path.length; pi++) {
-      if (typeof path[pi] !== 'string') {
-        if (keyedCount === level) {
-          ancestorPathEnd = pi + 1
-          break
-        }
-        keyedCount++
-      }
-    }
-    const ancestorPath =
-      ancestorPathEnd > 0 ? path.slice(0, ancestorPathEnd) : []
-
-    const ancestorEntry = getNode(editor.snapshot, ancestorPath)
-    if (!ancestorEntry) {
-      return
-    }
-    const ancestorNode = ancestorEntry.node
-    const ancestorRecord = ancestorNode as Record<string, unknown>
-    const currentChildren = Array.isArray(ancestorRecord[fieldName])
-      ? (ancestorRecord[fieldName] as Node[])
-      : []
-
-    // Use numeric index if the original path had a number at this level,
-    // since keyed lookup is ambiguous for duplicate keys.
-    const originalNumericIndex = numericIndices.get(level + 1)
-    const childIndex =
-      originalNumericIndex !== undefined
-        ? originalNumericIndex
-        : findIndexByKey(currentChildren, childKey)
-    if (childIndex === -1) {
+  for (let i = 0; i < resolvedNodeSegments.length; i++) {
+    const result = getNodeChildren(context, currentNode, currentParent)
+    if (!result) {
       return
     }
 
-    modifiedNode = {
-      ...ancestorNode,
-      [fieldName]: replaceChildren(
-        currentChildren,
-        childIndex,
-        1,
-        modifiedNode,
-      ),
+    const inputSegment = inputNodeSegments[i]
+    const resolvedSegment = resolvedNodeSegments[i]!
+    let index: number
+    if (typeof inputSegment === 'number') {
+      index = inputSegment
+    } else if (typeof resolvedSegment === 'number') {
+      index = resolvedSegment
+    } else if (isKeyedSegment(resolvedSegment)) {
+      index = result.children.findIndex(
+        (child) => child._key === resolvedSegment._key,
+      )
+    } else {
+      return
     }
+
+    const child = result.children[index]
+    if (!child) {
+      return
+    }
+
+    levels.push({
+      parentNode: currentNode,
+      fieldName: result.fieldName,
+      children: result.children,
+      index,
+    })
+    currentNode = child
+    currentParent = result.parent
   }
 
-  let rootIndex: number
-  const rootNumericIndex = numericIndices.get(0)
-  if (rootNumericIndex !== undefined) {
-    rootIndex = rootNumericIndex
-  } else if (keyedSegments.length > 0) {
-    const rootSegment = keyedSegments[0]!
-    const mapIndex = editor.blockIndexMap.get(serializePath([rootSegment]))
-    rootIndex =
-      mapIndex !== undefined
-        ? mapIndex
-        : findIndexByKey(editor.snapshot.context.value, rootSegment._key)
-  } else {
-    const firstSegment = path[0]
-    rootIndex = typeof firstSegment === 'number' ? firstSegment : -1
-  }
-  if (rootIndex === -1 || rootIndex >= editor.snapshot.context.value.length) {
+  const deepestLevel = levels.length - 1
+  if (deepestLevel < 0) {
     return
   }
+
+  let modifiedNode: Node = f(currentNode as N)
+
+  for (let level = deepestLevel; level >= 1; level--) {
+    const {parentNode, fieldName, children, index} = levels[level]!
+    modifiedNode = {
+      ...(parentNode as Node),
+      [fieldName]: replaceChildren(children, index, 1, modifiedNode),
+    }
+  }
+
   editor.snapshot.context.value = replaceChildren(
     editor.snapshot.context.value,
-    rootIndex,
+    levels[0]!.index,
     1,
     modifiedNode,
   ) as PortableTextBlock[]

--- a/packages/editor/src/paths/get-dirty-paths.ts
+++ b/packages/editor/src/paths/get-dirty-paths.ts
@@ -12,6 +12,7 @@ import type {
 } from '../schema/resolve-containers'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import {getChildFieldName} from './get-child-field-name'
+import {nodeSegment} from './node-segment'
 
 /**
  * Recursively collect descendant paths using numeric indices.
@@ -105,13 +106,7 @@ export function getDirtyPaths(
               continue
             }
             const childNode = child as Node
-            const hasUsableKey =
-              '_key' in child &&
-              typeof child._key === 'string' &&
-              child._key !== ''
-            const childPath: Path = hasUsableKey
-              ? [{_key: childNode._key}]
-              : [i]
+            const childPath: Path = [nodeSegment(childNode, i)]
             levels.push(childPath)
             // Seed the walker with the child's own registration so it
             // can recurse into the child's container fields. At root,
@@ -200,13 +195,11 @@ export function getDirtyPaths(
             }
 
             const childNode = child as Node
-            const hasUsableKey =
-              '_key' in child &&
-              typeof child._key === 'string' &&
-              child._key !== ''
-            const childPath: Path = hasUsableKey
-              ? [...nodePath, propertyName, {_key: childNode._key}]
-              : [...nodePath, propertyName, i]
+            const childPath: Path = [
+              ...nodePath,
+              propertyName,
+              nodeSegment(childNode, i),
+            ]
             levels.push(childPath)
             collectDescendantPaths(context, childNode, childPath, levels, seed)
           }

--- a/packages/editor/src/paths/node-segment.ts
+++ b/packages/editor/src/paths/node-segment.ts
@@ -1,0 +1,23 @@
+import type {KeyedSegment} from '../types/paths'
+
+/**
+ * A key only addresses a node when it's a non-empty string; sync payloads
+ * and hand-authored content can carry `undefined`, `null`, or `''`.
+ */
+export function hasUsableKey(key: unknown): key is string {
+  return typeof key === 'string' && key !== ''
+}
+
+/**
+ * The path segment that identifies `node` among its siblings: keyed when
+ * the node has a usable `_key`, otherwise the sibling index. A fabricated
+ * `{_key: undefined}` segment identifies nothing (several keyless siblings
+ * would all canonicalize to the same segment), so producers of resolved
+ * paths must fall back to the index until normalization mints a key.
+ */
+export function nodeSegment(
+  node: {_key?: unknown},
+  index: number,
+): KeyedSegment | number {
+  return hasUsableKey(node._key) ? {_key: node._key} : index
+}

--- a/packages/editor/src/traversal/get-ancestors.ts
+++ b/packages/editor/src/traversal/get-ancestors.ts
@@ -1,6 +1,7 @@
 import type {PortableTextBlock} from '@portabletext/schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {nodeSegment} from '../paths/node-segment'
 import {serializePath} from '../paths/serialize-path'
 import type {RegisteredContainer} from '../schema/resolve-containers'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -27,15 +28,16 @@ export function getAncestors(
   snapshot: TraversalSnapshot,
   path: Path,
 ): Array<{node: PortableTextBlock; path: Path}> {
-  // Collect keyed-segment indices to know where each ancestor's path ends.
+  // Collect node-segment indices (keyed or numeric) to know where each
+  // ancestor's path ends.
   const keyedIndices: Array<number> = []
   for (let i = 0; i < path.length; i++) {
-    if (isKeyedSegment(path[i])) {
+    if (isKeyedSegment(path[i]) || typeof path[i] === 'number') {
       keyedIndices.push(i)
     }
   }
 
-  // Need at least 2 keyed segments to have an ancestor (the last is self).
+  // Need at least 2 node segments to have an ancestor (the last is self).
   if (keyedIndices.length <= 1) {
     return []
   }
@@ -76,15 +78,18 @@ export function getAncestors(
         // disagree with the traversed value (snapshots that pair the live
         // map with a pre-apply value, e.g. `textPatch`). Fall back to a
         // linear scan in both cases.
-        node = currentChildren.find((child) => child._key === segment._key)
-        if (node && node._key !== undefined) {
-          resolvedPath[resolvedPath.length - 1] = {_key: node._key}
+        const scanIndex = currentChildren.findIndex(
+          (child) => child._key === segment._key,
+        )
+        node = scanIndex === -1 ? undefined : currentChildren[scanIndex]
+        if (node) {
+          resolvedPath[resolvedPath.length - 1] = nodeSegment(node, scanIndex)
         }
       }
     } else if (typeof segment === 'number') {
       node = currentChildren.at(segment)
       if (node) {
-        resolvedPath.push({_key: node._key})
+        resolvedPath.push(nodeSegment(node, segment))
       }
     } else {
       return []

--- a/packages/editor/src/traversal/get-children.ts
+++ b/packages/editor/src/traversal/get-children.ts
@@ -2,6 +2,7 @@ import {isTextBlock} from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {nodeSegment} from '../paths/node-segment'
 import {serializePath} from '../paths/serialize-path'
 import type {
   Containers,
@@ -53,9 +54,10 @@ export function getChildren(
       return []
     }
 
+    const nodeIndex = currentChildren.indexOf(node)
     currentPath = isRoot
-      ? [{_key: node._key}]
-      : [...currentPath, currentFieldName, {_key: node._key}]
+      ? [nodeSegment(node, nodeIndex)]
+      : [...currentPath, currentFieldName, nodeSegment(node, nodeIndex)]
     isRoot = false
 
     const next = getNodeChildren(snapshot.context, node, currentParent)
@@ -69,11 +71,11 @@ export function getChildren(
     currentParent = next.parent
   }
 
-  return currentChildren.map((child) => ({
+  return currentChildren.map((child, childIndex) => ({
     node: child,
     path: isRoot
-      ? [{_key: child._key}]
-      : [...currentPath, currentFieldName, {_key: child._key}],
+      ? [nodeSegment(child, childIndex)]
+      : [...currentPath, currentFieldName, nodeSegment(child, childIndex)],
   }))
 }
 

--- a/packages/editor/src/traversal/get-node.test.ts
+++ b/packages/editor/src/traversal/get-node.test.ts
@@ -370,3 +370,56 @@ describe(`${getNode.name} strips trailing field-name segments`, () => {
     expect(entry?.path).toEqual([{_key: 'b0'}, 'markDefs', {_key: 'm0'}])
   })
 })
+
+describe(`${getNode.name} keeps numeric segments for keyless nodes`, () => {
+  const testbed = createNodeTraversalTestbed()
+  const keylessSpan1 = {_type: 'span', text: 'foo', marks: []}
+  const keylessSpan2 = {_type: 'span', text: 'bar', marks: []}
+  const keylessBlock1 = {
+    _type: 'block',
+    children: [keylessSpan1],
+    markDefs: [],
+  }
+  const keylessBlock2 = {
+    _type: 'block',
+    children: [keylessSpan2],
+    markDefs: [],
+  }
+  const snapshot = {
+    context: {
+      ...testbed.snapshot.context,
+      value: [keylessBlock1, keylessBlock2] as never,
+    },
+    blockIndexMap: new Map<string, number>(),
+  }
+
+  test('numeric input resolves and stays numeric', () => {
+    const entry = getNode(snapshot, [1, 'children', 0])
+    expect(entry?.node).toBe(keylessSpan2)
+    expect(entry?.path).toEqual([1, 'children', 0])
+  })
+
+  test('a `{_key: undefined}` segment resolves to the sibling index', () => {
+    const entry = getNode(snapshot, [
+      {_key: undefined as unknown as string},
+      'children',
+      {_key: undefined as unknown as string},
+    ])
+    expect(entry?.node).toBe(keylessSpan1)
+    expect(entry?.path).toEqual([0, 'children', 0])
+  })
+
+  test('keyed segments stay keyed below a keyless ancestor', () => {
+    const keyedSpan = {_key: 'k100', _type: 'span', text: 'baz', marks: []}
+    const mixedSnapshot = {
+      context: {
+        ...testbed.snapshot.context,
+        value: [{_type: 'block', children: [keyedSpan], markDefs: []}] as never,
+      },
+      blockIndexMap: new Map<string, number>(),
+    }
+    const entry = getNode(mixedSnapshot, [0, 'children', {_key: 'k100'}])
+    expect(entry?.node).toBe(keyedSpan)
+    expect(entry?.path).toEqual([0, 'children', {_key: 'k100'}])
+  })
+})

--- a/packages/editor/src/traversal/get-node.ts
+++ b/packages/editor/src/traversal/get-node.ts
@@ -1,5 +1,6 @@
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
+import {nodeSegment} from '../paths/node-segment'
 import {serializePath} from '../paths/serialize-path'
 import type {RegisteredContainer} from '../schema/resolve-containers'
 import {isKeyedSegment} from '../utils/util.is-keyed-segment'
@@ -14,11 +15,14 @@ import type {TraversalSnapshot} from './traversal-snapshot'
  * field name strings name a structural descent into the previous
  * node's children, and numbers are resolved by index.
  *
- * The returned `path` always identifies the returned node: it's fully
- * keyed (numeric indices are converted to `KeyedSegment`s) and any
- * trailing segments in the input that point outside the value tree —
- * e.g. an object node's primitive field, or an annotation reached via
- * `'markDefs'` on a text block — are stripped so that
+ * The returned `path` always identifies the returned node: segments
+ * are keyed wherever the node has a usable `_key` (numeric indices are
+ * converted to `KeyedSegment`s), and stay numeric for nodes
+ * normalization has not keyed yet (a `{_key: undefined}` segment would
+ * not distinguish keyless siblings). Any trailing segments in the
+ * input that point outside the value tree — e.g. an object node's
+ * primitive field, or an annotation reached via `'markDefs'` on a text
+ * block — are stripped so that
  * `getNode(snapshot, entry.path).node === entry.node`.
  *
  * The walk stops when a string segment names a field that isn't the
@@ -109,15 +113,18 @@ export function resolveNode(
         // disagree with the traversed value (snapshots that pair the live
         // map with a pre-apply value, e.g. `textPatch`). Fall back to a
         // linear scan in both cases.
-        node = currentChildren.find((child) => child._key === segment._key)
-        if (node && node._key !== undefined) {
-          resolvedPath[resolvedPath.length - 1] = {_key: node._key}
+        const scanIndex = currentChildren.findIndex(
+          (child) => child._key === segment._key,
+        )
+        node = scanIndex === -1 ? undefined : currentChildren[scanIndex]
+        if (node) {
+          resolvedPath[resolvedPath.length - 1] = nodeSegment(node, scanIndex)
         }
       }
     } else if (typeof segment === 'number') {
       node = currentChildren.at(segment)
       if (node) {
-        resolvedPath.push({_key: node._key})
+        resolvedPath.push(nodeSegment(node, segment))
       }
     } else {
       return {status: 'missing'}

--- a/packages/editor/src/traversal/get-nodes.ts
+++ b/packages/editor/src/traversal/get-nodes.ts
@@ -2,6 +2,7 @@ import type {EditorSchema} from '../editor/editor-schema'
 import type {Node} from '../engine/interfaces/node'
 import type {Path} from '../engine/interfaces/path'
 import {isAncestorPath} from '../engine/path/is-ancestor-path'
+import {nodeSegment} from '../paths/node-segment'
 import {serializePath} from '../paths/serialize-path'
 import type {
   Containers,
@@ -80,10 +81,11 @@ function* walkStandalone(
     return
   }
 
-  for (const child of next.children) {
+  for (let childIndex = 0; childIndex < next.children.length; childIndex++) {
+    const child = next.children[childIndex]!
     const childPath: Path = isRoot
-      ? [{_key: child._key}]
-      : [...path, next.fieldName, {_key: child._key}]
+      ? [nodeSegment(child, childIndex)]
+      : [...path, next.fieldName, nodeSegment(child, childIndex)]
     yield {node: child, path: childPath}
     yield* walkStandalone(context, child, childPath, false, next.parent)
   }


### PR DESCRIPTION
`getNode` documents that the returned path identifies the returned node, then breaks the promise for keyless nodes: it canonicalizes every resolved segment to keyed form, so a keyless node comes back as `{_key: undefined}`, and several keyless siblings collapse into the same unmatchable segment. Every repair addressing such a node had to re-derive the real position with heuristics, and the heuristics are where the bugs lived (#3232 fixed two of them).

The contract fix: resolved paths keep the numeric sibling index wherever no usable key exists. Numeric segments are rare and transient (they exist only until normalization mints keys, which completes before anything renders), and the public `Path` type always admitted numbers.

- **Producers**: one shared `nodeSegment` helper in `getNode` (numeric branch and keyed fallback), `getChildren`, `getAncestors` (which also counts numeric segments as node boundaries now), and the standalone descendant walk. New `getNode` pins, red on the old canonicalization.
- **Consumers that assumed all-keyed paths**: `apply-operation`'s root-block routing accepts a numeric first segment; `modifyDescendant` is rebuilt on one ordered node-segment walk instead of parallel keyed/numeric bookkeeping (its own commit, behavior-neutral).
- **The payoff**: `normalize-node`'s missing-key rule shrinks to a plain `set` at the resolved path. The whole path-reconstruction walk deletes: the sibling scans, the by-reference resolution, and the `subtreeContainsNode` ancestor containment from #3232. Emitted repair patch shapes are pinned unchanged by the normalization suites.

Verified with the full unit suite (1433) and the full chromium browser suite (2044) on the stacked tree. What the suites do not cover, stated honestly: a numeric segment captured into a selection or path ref during the transient window is not shifted by sibling inserts or removals; nothing observed hits it, and the durable answer is the key-assignment identity transition tracked as follow-up work on the resolved-path contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core document path resolution, edits, and normalization in the editor engine; behavior change is scoped to keyless/transient nodes but incorrect paths could mis-target repairs or patches.
> 
> **Overview**
> **Resolved paths now identify keyless siblings by index** instead of collapsing them into indistinguishable `{_key: undefined}` segments. `getNode`, `getChildren`, `getAncestors`, and descendant walks use a shared `nodeSegment` / `hasUsableKey` helper so segments stay numeric until normalization assigns a key; keyed segments are unchanged when a usable `_key` exists.
> 
> **Downstream consumers align with that contract.** Root-block routing in `apply-operation` accepts a numeric first segment; `modifyDescendant` walks paths once with explicit numeric-vs-keyed resolution (input numeric segments win over ambiguous keyed lookup). Dirty-path collection uses `nodeSegment` for new children.
> 
> **Normalization for missing `_key` is simplified:** repairs apply `set` at the already-resolved path, removing the old tree walk, sibling heuristics, and `subtreeContainsNode`. New `getNode` tests cover numeric paths, `{_key: undefined}` input, and keyed children under keyless ancestors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07fb4409fd8d493e5983f580faab14ee4461610b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

