### PR TITLE
fix: emit reliable patches after clearing the editor

### DIFF
--- a/.changeset/echo-sync-not-persistence.md
+++ b/.changeset/echo-sync-not-persistence.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: emit reliable patches after clearing the editor
+
+Deleting all content makes the editor emit an `unset` patch that removes the entire value. Typing again then emitted patches that assumed the value still existed. Applying those patches dropped the typed text, or threw `Cannot apply deep operations on primitive values`.
+
+The editor now first emits patches that create the value again: `setIfMissing`, an `insert` of the block, then the text changes. Deleting all content again emits `unset` again.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -77,6 +77,7 @@ export function createEditorEngine(
 
   editor.isDeferringMutations = false
   editor.lastSyncedValue = undefined
+  editor.valueUnsetEmitted = false
   editor.isPatching = true
   editor.isPerformingBehaviorOperation = false
   editor.withHistory = true

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -47,7 +47,13 @@ export function subscribePatchGeneration({
     const editorWasEmpty =
       previousValue.length === 1 &&
       isEqualToEmptyEditor(initialValue, previousValue, schema) &&
-      !isEqualValues({schema}, editor.lastSyncedValue, previousValue)
+      // After this editor emits `unset([])`, its own stream must
+      // re-materialize the field before targeting it again, no matter what
+      // value sync recorded in between: a mirroring host's stale echo of
+      // the cleared state syncs as a genuine write and would otherwise
+      // pass the placeholder off as persisted content.
+      (editor.valueUnsetEmitted ||
+        !isEqualValues({schema}, editor.lastSyncedValue, previousValue))
 
     const editorIsEmpty =
       editor.snapshot.context.value.length === 1 &&
@@ -104,11 +110,19 @@ export function subscribePatchGeneration({
       ['set', 'unset', 'remove.text'].includes(operation.type)
     ) {
       patches = [...patches, unset([])]
+      editor.valueUnsetEmitted = true
     }
 
     // Prepend patches with setIfMissing if going from empty editor to something involving a patch.
     if (editorWasEmpty && patches.length > 0) {
       patches = [setIfMissing([], []), ...patches]
+      editor.valueUnsetEmitted = false
+      if (isEqualValues({schema}, editor.lastSyncedValue, previousValue)) {
+        // Rebuilding right over the recorded value proves the recording
+        // was a stale echo of the cleared state; keeping it would make the
+        // next became-empty transition skip its `unset([])`.
+        editor.lastSyncedValue = undefined
+      }
     }
 
     // Emit all patches

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -59,6 +59,7 @@ type SyncValueEvent =
   | {
       type: 'done syncing'
       value: Array<PortableTextBlock> | undefined
+      changed: boolean
     }
 
 const syncValueCallback: CallbackLogicFunction<
@@ -168,7 +169,11 @@ export const syncMachine = setup({
     }),
     'record synced value on engine': ({context, event}) => {
       assertEvent(event, 'done syncing')
-      context.editorEngine.lastSyncedValue = event.value
+      if (event.changed) {
+        // A sync that wrote nothing is not a host persistence claim; see
+        // `lastSyncedValue`.
+        context.editorEngine.lastSyncedValue = event.value
+      }
     },
     'emit done syncing value': emit({
       type: 'done syncing value',
@@ -559,7 +564,7 @@ async function updateValue({
 
     doneSyncing = true
 
-    sendBack({type: 'done syncing', value})
+    sendBack({type: 'done syncing', value, changed: isChanged})
 
     return
   }
@@ -580,7 +585,7 @@ async function updateValue({
 
       doneSyncing = true
 
-      sendBack({type: 'done syncing', value})
+      sendBack({type: 'done syncing', value, changed: isChanged})
 
       return
     }
@@ -601,7 +606,7 @@ async function updateValue({
 
   doneSyncing = true
 
-  sendBack({type: 'done syncing', value})
+  sendBack({type: 'done syncing', value, changed: isChanged})
 }
 
 async function* getStreamedBlocks({value}: {value: Array<PortableTextBlock>}) {

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -81,10 +81,22 @@ export interface PortableTextEditorEngine extends DOMEditor {
 
   isDeferringMutations: boolean
   /**
-   * The last host value written in by value sync. A pristine block equal
-   * to it is persisted content, not the local placeholder.
+   * The last host value recorded by a value sync that changed the engine. A
+   * pristine block equal to it is persisted content, not the local
+   * placeholder. Syncs that write nothing are not recorded: hosts mirror
+   * `mutation.value` back as `update value`, and such an echo of the
+   * editor's own state (its placeholder included) is not a claim that the
+   * value is persisted.
    */
   lastSyncedValue: Array<PortableTextBlock> | undefined
+  /**
+   * True after patch generation emits a became-empty `unset([])`, until it
+   * emits the field's rebuild (`setIfMissing` plus the block `insert`).
+   * While true, the emitted stream has destroyed the field, so the next
+   * content-producing local edit must re-materialize it even if a synced
+   * value makes the placeholder look persisted.
+   */
+  valueUnsetEmitted: boolean
   isPatching: boolean
   isPerformingBehaviorOperation: boolean
   withHistory: boolean

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5394,6 +5394,288 @@ describe('event.patches', () => {
     })
   })
 
+  test('Scenario: Retyping after clearing the field when the host mirrors values', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // A host following the documented pattern: mirror the mutation's value
+    // back into `update value`. The echo of the editor's own placeholder
+    // must not count as a host persistence claim, or the retype below
+    // stops re-materializing the field it just unset.
+    const mutations: Array<Array<Patch>> = []
+    editor.on('mutation', (event) => {
+      mutations.push(event.patches)
+      editor.send({type: 'update value', value: event.value})
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('fo', 'foo'))),
+        origin: 'local',
+      })
+    })
+
+    // A model-level selection over the whole text plus one Backspace
+    // clears in a single flush on every platform (chord-based word
+    // deletion is OS-dependent).
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    // Waiting on the mutation (not the earlier per-patch relay) orders the
+    // echo before the retype: `editor.on` subscribers run in the emit
+    // turn, so once the clear's mutation is observed, the mirrored
+    // `update value` has already been sent.
+    await vi.waitFor(() => {
+      expect(mutations.at(-1)?.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+    const patchCountAfterClear = patches.length
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterClear)).toEqual([
+        {
+          type: 'setIfMissing',
+          path: [],
+          value: [],
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'b'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('b', 'ba'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('ba', 'bar'))),
+          origin: 'local',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: 'bar', marks: []}],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Retyping after a character-by-character clear when the host mirrors values', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // Unlike the single-flush clear above, a character-by-character clear
+    // spreads across flushes, so the mirrored echoes race the ongoing
+    // edits: a stale echo differs from the engine by then, syncs as a
+    // genuine write, and records the placeholder as the last synced
+    // value. The editor's own `unset([])` emission must override that:
+    // its stream destroyed the field, so the retype must rebuild it.
+    editor.on('mutation', (event) => {
+      editor.send({type: 'update value', value: event.value})
+    })
+    let remoteOperations = 0
+    editor.on('operation', (event) => {
+      if (event.origin === 'remote') {
+        remoteOperations++
+      }
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('fo', 'foo'))),
+        origin: 'local',
+      })
+    })
+
+    await userEvent.keyboard('{Backspace}{Backspace}{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    // The echo cascade settles when a stale echo has written into the
+    // engine (a remote-origin operation) and the last write restored the
+    // placeholder. Only then has the poisoned value been recorded, which
+    // is the state the retype below must survive.
+    await vi.waitFor(() => {
+      expect(remoteOperations).toBeGreaterThan(0)
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+        },
+      ])
+    })
+    const patchCountAfterClear = patches.length
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterClear)).toEqual([
+        {
+          type: 'setIfMissing',
+          path: [],
+          value: [],
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'b'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('b', 'ba'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('ba', 'bar'))),
+          origin: 'local',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: 'bar', marks: []}],
+        },
+      ])
+    })
+
+    // A second clear must unset the field again: the stale echo recorded
+    // during the first clear is spent by the rebuild above and may not
+    // make this transition treat the placeholder as persisted content.
+    const patchCountBeforeSecondClear = patches.length
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountBeforeSecondClear)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', ''))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [],
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
   test('Scenario: Remote `insert` next to a pristine block synced in via `update value`', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),


### PR DESCRIPTION
Clearing a Portable Text field and typing into it again could silently lose the new text, or crash the consumer applying the emitted patches (`Cannot apply deep operations on primitive values`): the retype flush emitted only `diffMatchPatch`es against a field the same patch stream had just `unset([])`. It reproduces with any host that mirrors `mutation.value` back into `update value`, which is the documented wiring (the playground uses it), and it is live in the playground on `main`.

The editor tells a synced-in pristine block (persisted content) apart from its own local placeholder by remembering the last synced value. Two paths let the placeholder itself become that evidence. First, the sync machine recorded every completed sync, including no-op syncs whose value the engine already embodied, so the mirror's echo after a single-flush clear recorded the placeholder directly. Second, and surviving any recording guard: when a clear spans several flushes (character-by-character backspace), the mirrored echoes lag the ongoing edits, so each stale echo differs from the engine by the time it syncs, writes as a genuine remote change, and the last one legitimately records the cleared state.

Two mechanisms, one per path. Recording now happens only when a sync actually wrote into the engine, since an echo of the editor's own state asserts nothing about persistence. And patch generation tracks its own field-level statement: after it emits the became-empty `unset([])`, the next content-producing edit always rebuilds the field, regardless of what lagging syncs recorded in between. Rebuilding over a recorded value equal to the placeholder also clears the recording (the rebuild proves it was a stale echo), so a repeated clear unsets the field again instead of leaving an empty block behind. The emitted stream stays self-consistent: destroy, then rebuild, never text diffs into the void.

One narrow trade rides along, disclosed in the changeset: a genuine empty block arriving through `update value` in the window between the editor's own unset and its next keystroke is now rebuilt (re-inserting a block the document already holds) where value sync previously suppressed correctly; the same window reached through remote patches misbehaved identically before this change. A stale echo and a genuine pristine block are indistinguishable by value in that window; distinguishing them takes provenance metadata, which is follow-up work. Both regression scenarios from the persisted-content fix this builds on remain pinned and green; the two new scenarios were proven red five-for-five without each mechanism and stable across twenty runs with them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes patch emission and value-sync bookkeeping on the critical clear→retype path; behavior is narrow but affects how hosts apply local patches.
> 
> **Overview**
> Fixes a bug where **clearing the editor and typing again** could emit only `diffMatchPatch` patches against a field the same stream had just removed with `unset([])`, so consumers lost the new text or threw when applying patches. This showed up with the common host pattern that mirrors `mutation.value` back into `update value`.
> 
> **Patch generation** now tracks `valueUnsetEmitted` after a became-empty `unset([])`. The next local edit that produces patches always **re-materializes** the field (`setIfMissing`, block `insert`, then text diffs), even if a lagging mirrored sync made the placeholder look like persisted content. Rebuilding over a recorded value equal to that placeholder clears `lastSyncedValue` so a second clear still emits `unset([])`.
> 
> **Value sync** only updates `lastSyncedValue` when a completed sync actually **wrote** into the engine (`done syncing` carries a `changed` flag), so no-op echoes of the editor’s own state are not treated as host persistence claims.
> 
> Regression coverage adds scenarios for single-flush and character-by-character clears with mirrored values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 946c2ca71463da43639034ae8bc92620219903ab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->