### PR TITLE
fix: park external repair patches until the first local edit

### DIFF
--- a/.changeset/park-external-repair-patches.md
+++ b/.changeset/park-external-repair-patches.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: park external repair patches until the first local edit
+
+When remote patches deliver content the engine has to repair (a missing `_key`, missing children, a duplicate key), the repair patches are no longer published immediately from an untouched editor. They are held and published together with the first local edit, ahead of it, so the document always learns a repair before any edit references it. An editor the user never edits no longer writes repairs to the document, a read-only editor never publishes them, and a value sync or a conflicting remote patch discards held repairs that no longer apply.

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -283,6 +283,10 @@ function createActors(config: {
             ...event,
             type: 'internal.patch',
             value: config.editorEngine.snapshot.context.value,
+            // The sync machine's own repair patches keep publishing
+            // immediately until that channel is deleted; parking covers
+            // the normalization-executed repairs only.
+            isExternalRepair: false,
           })
           break
 

--- a/packages/editor/src/editor/editor-machine.ts
+++ b/packages/editor/src/editor/editor-machine.ts
@@ -58,6 +58,16 @@ export type ExternalEditorEvent =
 type InternalPatchEvent = NamespaceEvent<PatchEvent, 'internal'> & {
   operationId?: string
   value: Array<PortableTextBlock>
+  /**
+   * Captured from the operation event that produced the patch: the
+   * operation was executed by normalization while external content
+   * (remote patches or a value sync) was being applied. Such repair
+   * patches park while the editor is pristine and flush ahead of the
+   * first local edit, so the document learns a repair (e.g. a minted
+   * `_key`) before any edit references it, and an editor nobody
+   * touches never writes to the document.
+   */
+  isExternalRepair: boolean
 }
 
 /**
@@ -460,6 +470,10 @@ export const editorMachine = setup({
 
       return isInNormalization(context.editorEngine.applyContext)
     },
+    'patch is external repair': ({event}) => {
+      assertEvent(event, 'internal.patch')
+      return event.isExternalRepair
+    },
   },
 }).createMachine({
   id: 'editor',
@@ -811,7 +825,7 @@ export const editorMachine = setup({
                       on: {
                         'internal.patch': [
                           {
-                            guard: 'engine is normalizing node',
+                            guard: 'patch is external repair',
                             actions: 'defer event',
                           },
                           {

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -5,6 +5,7 @@ import {
   unset,
   type Patch,
 } from '@portabletext/patches'
+import {hasRemoteFrame, isInNormalization} from '../engine/core/apply-context'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import {isEqualValues} from '../internal-utils/equality'
 import {
@@ -119,6 +120,8 @@ export function subscribePatchGeneration({
           patch: {...patch, origin: 'local'},
           operationId: event.undoStepId,
           value: editor.snapshot.context.value,
+          isExternalRepair:
+            isInNormalization(event.context) && hasRemoteFrame(event.context),
         })
       }
     }

--- a/packages/editor/tests/collaborative-editing.test.tsx
+++ b/packages/editor/tests/collaborative-editing.test.tsx
@@ -1,6 +1,7 @@
 import {applyAll, diffMatchPatch, type Patch} from '@portabletext/patches'
 import {defineSchema, type PortableTextBlock} from '@portabletext/schema'
 import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
+import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent, type Locator} from 'vitest/browser'
 import type {Editor} from '../src'
@@ -1592,6 +1593,161 @@ describe('Collaborative editing', () => {
           style: 'normal',
         },
       ])
+    })
+  })
+
+  describe('Parked repair convergence', () => {
+    test('Scenario: Two clients repairing the same keyless node converge on the editing client\u2019s key', async () => {
+      const sharedKeyGenerator = createTestKeyGenerator()
+      const blockKey = sharedKeyGenerator()
+      const spanKey = sharedKeyGenerator()
+      const initialValue = [
+        {
+          _type: 'block',
+          _key: blockKey,
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        },
+      ] satisfies Array<PortableTextBlock>
+
+      const patchesA: Array<Patch> = []
+      const patchesB: Array<Patch> = []
+
+      const {editor: editorA} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator('ea-'),
+        initialValue,
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+        children: (
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                const {origin: _, ...patch} = event.patch
+                patchesA.push(patch)
+              }
+            }}
+          />
+        ),
+      })
+
+      const {editor: editorB} = await createTestEditor({
+        keyGenerator: createTestKeyGenerator('eb-'),
+        initialValue,
+        schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+        children: (
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                const {origin: _, ...patch} = event.patch
+                patchesB.push(patch)
+              }
+            }}
+          />
+        ),
+      })
+
+      // Both clients receive the same keyless span; each parks its own
+      // competing mint.
+      const keylessInsert: Patch = {
+        type: 'insert',
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        position: 'after',
+        items: [{_type: 'span', text: 'bar', marks: ['strong']}],
+        origin: 'remote',
+      }
+      editorA.send({
+        type: 'patches',
+        patches: [keylessInsert],
+        snapshot: undefined,
+      })
+      editorB.send({
+        type: 'patches',
+        patches: [keylessInsert],
+        snapshot: undefined,
+      })
+
+      await vi.waitFor(() => {
+        expect(editorA.getSnapshot().context.value?.[0]?.children).toHaveLength(
+          2,
+        )
+        expect(editorB.getSnapshot().context.value?.[0]?.children).toHaveLength(
+          2,
+        )
+        expect(patchesA).toEqual([])
+        expect(patchesB).toEqual([])
+      })
+
+      // Client A edits: its parked mint flushes ahead of the edit.
+      editorA.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}],
+            offset: 3,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}],
+            offset: 3,
+          },
+        },
+      })
+      editorA.send({type: 'insert.text', text: 'a'})
+
+      await vi.waitFor(() => {
+        expect(patchesA).toEqual([
+          {
+            type: 'set',
+            path: [{_key: blockKey}, 'children', 1, '_key'],
+            value: 'ea-k2',
+          },
+          {
+            type: 'diffMatchPatch',
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('bar', 'bara'))),
+          },
+        ])
+      })
+
+      // Client B receives A's patches: the mint rekeys B's copy, and B's
+      // own parked competitor dies with the conflict.
+      editorB.send({
+        type: 'patches',
+        patches: patchesA.map((patch) => ({...patch, origin: 'remote'})),
+        snapshot: undefined,
+      })
+
+      await vi.waitFor(() => {
+        expect(editorB.getSnapshot().context.value).toEqual(
+          editorA.getSnapshot().context.value,
+        )
+      })
+
+      // B edits the converged span: only the edit publishes, no stale
+      // competing mint.
+      editorB.send({
+        type: 'select',
+        at: {
+          anchor: {
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}],
+            offset: 4,
+          },
+          focus: {
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}],
+            offset: 4,
+          },
+        },
+      })
+      editorB.send({type: 'insert.text', text: 'b'})
+
+      await vi.waitFor(() => {
+        expect(patchesB).toEqual([
+          {
+            type: 'diffMatchPatch',
+            path: [{_key: blockKey}, 'children', {_key: 'ea-k2'}, 'text'],
+            value: stringifyPatches(makePatches(makeDiff('bara', 'barab'))),
+          },
+        ])
+      })
     })
   })
 

--- a/packages/editor/tests/container-normalization.test.tsx
+++ b/packages/editor/tests/container-normalization.test.tsx
@@ -1419,18 +1419,7 @@ describe('container normalization', () => {
           ],
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: calloutKey}, 'content', 0, 'children', 0, '_key'],
-          value: 'k5',
-        },
-        {
-          type: 'set',
-          path: [{_key: calloutKey}, 'content', 0, '_key'],
-          value: 'k6',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -4345,20 +4345,7 @@ describe('event.patches', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        setIfMissing([], [{_key: blockKey}, 'children']),
-        insert([{_type: 'span', _key: 'k3', text: '', marks: []}], 'before', [
-          {_key: blockKey},
-          'children',
-          {_key: inlineKey},
-        ]),
-        setIfMissing([], [{_key: blockKey}, 'children']),
-        insert([{_type: 'span', _key: 'k4', text: '', marks: []}], 'after', [
-          {_key: blockKey},
-          'children',
-          {_key: inlineKey},
-        ]),
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -4419,10 +4406,7 @@ describe('event.patches', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        set('', [{_key: blockKey}, 'children', {_key: spanKey}, 'text']),
-        unset([]),
-      ])
+      expect(patches).toEqual([])
     })
   })
 

--- a/packages/editor/tests/normalization.test.tsx
+++ b/packages/editor/tests/normalization.test.tsx
@@ -1,5 +1,7 @@
-import type {Patch} from '@portabletext/patches'
+import {applyAll, type Patch} from '@portabletext/patches'
+import type {PortableTextBlock} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
+import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {defineSchema} from '../src'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
@@ -187,24 +189,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: 'new-block'}, 'children'],
-          value: [],
-        },
-        {
-          type: 'setIfMissing',
-          path: [{_key: 'new-block'}, 'children'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: 'new-block'}, 'children', 0],
-          position: 'before',
-          items: [{_type: 'span', _key: 'k2', text: '', marks: []}],
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -272,19 +257,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'setIfMissing',
-          path: [{_key: 'new-block'}, 'children'],
-          value: [],
-        },
-        {
-          type: 'insert',
-          path: [{_key: 'new-block'}, 'children', 0],
-          position: 'before',
-          items: [{_type: 'span', _key: 'k2', text: '', marks: []}],
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -345,13 +318,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: 'k0'}, 'children', 1, '_key'],
-          value: 'k4',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -412,18 +379,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', 1, '_key'],
-          value: 'k4',
-        },
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', 0, '_key'],
-          value: 'k5',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -502,28 +458,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [1, 'children', 0, '_key'],
-          value: 'k4',
-        },
-        {
-          type: 'set',
-          path: [1, '_key'],
-          value: 'k5',
-        },
-        {
-          type: 'set',
-          path: [0, 'children', 0, '_key'],
-          value: 'k6',
-        },
-        {
-          type: 'set',
-          path: [0, '_key'],
-          value: 'k7',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -589,18 +524,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', 1, '_key'],
-          value: 'k4',
-        },
-        {
-          type: 'set',
-          path: [{_key: blockKey}, 'children', 0, '_key'],
-          value: 'k5',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -670,18 +594,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [1, 'children', 0, '_key'],
-          value: 'k4',
-        },
-        {
-          type: 'set',
-          path: [1, '_key'],
-          value: 'k5',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -746,13 +659,7 @@ describe('normalization', () => {
           src: '/photo.jpg',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [1, '_key'],
-          value: 'k4',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -821,13 +728,7 @@ describe('normalization', () => {
         },
       ])
 
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockBKey}, 'children', {_key: spanBKey}, 'text'],
-          value: '',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -1070,13 +971,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [1, '_key'],
-          value: 'k4',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -1130,13 +1025,7 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
-      expect(patches).toEqual([
-        {
-          type: 'set',
-          path: [{_key: blockKey}, '_type'],
-          value: 'block',
-        },
-      ])
+      expect(patches).toEqual([])
     })
   })
 
@@ -1190,13 +1079,263 @@ describe('normalization', () => {
           style: 'normal',
         },
       ])
+      expect(patches).toEqual([])
+    })
+  })
+
+  test('Scenario: parked repairs flush ahead of the first local edit', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    const keylessSpan = {_type: 'span', text: 'bar', marks: ['strong']}
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [keylessSpan],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [
+            {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+            {_type: 'span', _key: 'k4', text: 'bar', marks: ['strong']},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(patches).toEqual([])
+    })
+
+    // The edit addresses the repaired span by its minted key, so the
+    // repair must reach the document first or the edit's patch targets a
+    // key the document does not have.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: blockKey}, 'children', {_key: 'k4'}], offset: 3},
+        focus: {path: [{_key: blockKey}, 'children', {_key: 'k4'}], offset: 3},
+      },
+    })
+    editor.send({type: 'insert.text', text: 'a'})
+
+    await vi.waitFor(() => {
       expect(patches).toEqual([
         {
           type: 'set',
-          path: [{_key: blockKey}, 'children', {_key: spanKey}, '_type'],
-          value: 'span',
+          path: [{_key: blockKey}, 'children', 1, '_key'],
+          value: 'k4',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: 'k4'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', 'bara'))),
         },
       ])
+    })
+
+    // The document, replaying what it received (the remote insert, then
+    // the emitted patches), ends up with the engine's value.
+    const documentValue = applyAll(
+      applyAll(initialValue, [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [keylessSpan],
+          origin: 'remote',
+        },
+      ]),
+      patches,
+    ) as Array<PortableTextBlock>
+    expect(documentValue).toEqual(editor.getSnapshot().context.value)
+  })
+
+  test('Scenario: a value sync discards parked repairs', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const initialValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue,
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [{_type: 'span', text: 'bar', marks: ['strong']}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value?.[0]?.children).toHaveLength(2)
+    })
+
+    // The host sends a fresh snapshot that already carries proper keys:
+    // the parked repair now describes a node the document never had, so
+    // it must die with the sync instead of publishing later.
+    const syncedValue = [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [
+          {_type: 'span', _key: spanKey, text: 'foo', marks: []},
+          {_type: 'span', _key: 'remote-key', text: 'bar', marks: ['strong']},
+        ],
+        markDefs: [],
+        style: 'normal',
+      },
+    ]
+    editor.send({type: 'update value', value: syncedValue})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(syncedValue)
+    })
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {
+          path: [{_key: blockKey}, 'children', {_key: 'remote-key'}],
+          offset: 3,
+        },
+        focus: {
+          path: [{_key: blockKey}, 'children', {_key: 'remote-key'}],
+          offset: 3,
+        },
+      },
+    })
+    editor.send({type: 'insert.text', text: 'a'})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: blockKey}, 'children', {_key: 'remote-key'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', 'bara'))),
+        },
+      ])
+    })
+  })
+
+  test('Scenario: toggling read-only to editable publishes no parked repairs', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const blockKey = keyGenerator()
+    const spanKey = keyGenerator()
+    const {editor} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+      initialValue: [
+        {
+          _type: 'block',
+          _key: blockKey,
+          children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ],
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              const {origin: _, ...patch} = event.patch
+              patches.push(patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    editor.send({type: 'update readOnly', readOnly: true})
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [{_key: blockKey}, 'children', {_key: spanKey}],
+          position: 'after',
+          items: [{_type: 'span', text: 'bar', marks: ['strong']}],
+          origin: 'remote',
+        },
+      ],
+      snapshot: undefined,
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value?.[0]?.children).toHaveLength(2)
+    })
+
+    editor.send({type: 'update readOnly', readOnly: false})
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([])
     })
   })
 })

--- a/packages/editor/tests/parked-repair-shift.test.tsx
+++ b/packages/editor/tests/parked-repair-shift.test.tsx
@@ -1,0 +1,104 @@
+import type {Patch} from '@portabletext/patches'
+import {createTestKeyGenerator} from '@portabletext/test'
+import {expect, test, vi} from 'vitest'
+import {defineSchema} from '../src'
+import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
+import {createTestEditor} from '../src/test/vitest'
+
+test.fails('Scenario: sibling traffic while a numeric repair is parked shifts its flush target', async () => {
+  const patches: Array<Patch> = []
+  const keyGenerator = createTestKeyGenerator()
+  const blockKey = keyGenerator()
+  const spanKey = keyGenerator()
+  const {editor} = await createTestEditor({
+    keyGenerator,
+    schemaDefinition: defineSchema({decorators: [{name: 'strong'}]}),
+    initialValue: [
+      {
+        _type: 'block',
+        _key: blockKey,
+        children: [{_type: 'span', _key: spanKey, text: 'foo', marks: []}],
+        markDefs: [],
+        style: 'normal',
+      },
+    ],
+    children: (
+      <EventListenerPlugin
+        on={(event) => {
+          if (event.type === 'patch') {
+            const {origin: _, ...patch} = event.patch
+            patches.push(patch)
+          }
+        }}
+      />
+    ),
+  })
+
+  // A keyless span arrives and its mint parks at children[1].
+  editor.send({
+    type: 'patches',
+    patches: [
+      {
+        type: 'insert',
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        position: 'after',
+        items: [{_type: 'span', text: 'bar', marks: ['strong']}],
+        origin: 'remote',
+      },
+    ],
+    snapshot: undefined,
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value?.[0]?.children).toHaveLength(2)
+  })
+
+  // A collaborator inserts another span BEFORE it: indices shift, the
+  // parked patch's `children[1]` now names this new span in the document.
+  editor.send({
+    type: 'patches',
+    patches: [
+      {
+        type: 'insert',
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        position: 'before',
+        items: [{_type: 'span', _key: 'remote-1', text: 'X', marks: []}],
+        origin: 'remote',
+      },
+    ],
+    snapshot: undefined,
+  })
+
+  await vi.waitFor(() => {
+    expect(editor.getSnapshot().context.value?.[0]?.children).toHaveLength(3)
+  })
+
+  // First local edit flushes the parked mint.
+  editor.send({
+    type: 'select',
+    at: {
+      anchor: {
+        path: [{_key: blockKey}, 'children', {_key: spanKey}],
+        offset: 3,
+      },
+      focus: {path: [{_key: blockKey}, 'children', {_key: spanKey}], offset: 3},
+    },
+  })
+  editor.send({type: 'insert.text', text: 'a'})
+
+  await vi.waitFor(() => {
+    expect(patches.length).toBeGreaterThan(0)
+  })
+  // The document at this point holds [X, foo, bar]: the keyless span sits
+  // at index 2, and the parked mint must address it there. Today the mint
+  // flushes with the index frozen at park time (`children[1]`), which
+  // document-side rekeys the collaborator's span X instead. The fix needs
+  // a document-shaped shadow to re-anchor against; the engine's own value
+  // is no oracle because local normalization fallout (span merges) changes
+  // engine indices before the merge patches reach the document.
+  expect(patches[0]).toEqual({
+    type: 'set',
+    path: [{_key: blockKey}, 'children', 2, '_key'],
+    value: 'k4',
+  })
+})


### PR DESCRIPTION
An editor that receives broken content from outside (a keyless span in a remote patch, a block without children) repairs it locally, and today it also publishes the repair patches immediately, even when the user never touched the editor. Opening a document should not mutate it, and N clients receiving the same broken content race their competing repairs (each mints different keys) to the document.

The machinery to hold repairs back already exists: the pristine state parks patch events and flushes them on the first local edit. It never engaged for remote-triggered repairs because its guard read the engine's live apply context, and xstate queues the `internal.patch` send, so the normalization frame was always gone by guard time. The guard said no; the leak was systematic.

The fix is capture instead of live reads: each `internal.patch` carries `isExternalRepair` (executed by normalization while remote content was applied), stamped from the operation event's captured frames, and the guard reads the event.

What this changes, deliberately (changeset included):

- An untouched editor never writes repairs to the document. Fifteen existing tests pinned the immediate publication; they now pin silence.
- Parked repairs flush ahead of the first local edit, so the document learns a minted key before the edit's patch references it. Pinned by a replay sentinel: applying the emitted patch stream document-side reproduces the engine value.
- A value sync or a conflicting remote patch discards parked repairs (existing machine actions, now reachable; pinned).
- Two clients repairing the same keyless node converge on the editing client's key; the other client's parked competitor dies with the conflict (pinned in the collaboration suite).
- A read-only editor toggled editable without an edit publishes nothing (pinned).

The sync machine's own repair channel (`validateValue` auto-resolutions) still publishes immediately; it is stamped `isExternalRepair: false` and its deletion is tracked separately.

One known gap, pinned as an expected failure rather than hidden: while a numeric-addressed repair is parked, sibling traffic into the same array shifts the index it was built against, and the flush would rekey whatever node sits at the stale index. The conflict discard is containment-based and does not see sibling shifts, and the engine's own value cannot re-anchor the patch (local normalization fallout diverges engine indices from document indices mid-stream). The window needs a keyless repair, concurrent sibling traffic into the same array, and then a local edit; the correct fix is a document-shaped shadow to resolve flush addresses against, tracked as a follow-up. The immediate publication this PR replaces had no such window; it had the unconditional problems above instead.

All fifteen rewritten tests and the four sentinels are red on the old guard. Full unit (1433) and chromium (2050) suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when collaborative documents receive patches and which repair operations hit persistence—incorrect parking or flush order could break multi-client convergence or leave documents with wrong keys.
> 
> **Overview**
> **Remote normalization repairs no longer publish from a pristine editor.** Patches minted while applying remote patches or value sync (missing `_key`, empty `children`, duplicate keys, etc.) are **parked** in the existing pristine `pendingEvents` queue instead of leaking immediately—so merely opening or viewing a document does not mutate it, and multiple clients no longer race competing key-mints to the server.
> 
> Each `internal.patch` now carries **`isExternalRepair`**, captured on the operation event (`isInNormalization` + `hasRemoteFrame`) rather than read from the engine at guard time (which was always false after XState queued the event). The pristine-state guard switches from **`engine is normalizing node`** to **`patch is external repair`** so only those repairs defer; sync-machine repairs stay **`isExternalRepair: false`** and still publish immediately.
> 
> **On the first local edit**, parked external repairs flush **before** the edit patches (so `_key` sets precede edits that reference them). **Value sync**, conflicting remote patches, and read-only→editable without typing still discard or withhold stale parked repairs. Tests are updated (many now expect **no** patches until an edit) plus new collaboration/convergence coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58e8cce576c67f55430af5b936fc13a6e6e1484. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
