### PR TITLE
docs: give the markdown round-trip contract a canonical page

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -204,6 +204,7 @@ export default defineConfig({
           items: [
             {slug: 'conversion/html-to-portable-text'},
             {slug: 'conversion/markdown-to-portable-text'},
+            {slug: 'conversion/markdown-round-tripping'},
           ],
         },
         {slug: 'why-portable-text'},

--- a/apps/docs/src/content/docs/conversion/markdown-round-tripping.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-round-tripping.mdx
@@ -1,0 +1,269 @@
+---
+title: Markdown round-tripping
+description: What a Markdown → Portable Text → Markdown round trip preserves, normalizes, and degrades with @portabletext/markdown.
+---
+
+{/* This page is the canonical source for round-trip behavior. packages/markdown/README.md and apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx (Round-trip behavior section) both carry condensed summaries; keep all three in sync, a claim corrected here is stale there. */}
+
+Converting Markdown to Portable Text and back with `markdownToPortableText` and `portableTextToMarkdown` isn't a lossless mirror. It's a contract with six guarantees and a short list of named exceptions. This page is for anyone evaluating a Markdown-based pipeline, an AI agent that reads or writes Markdown, an import/export tool, a migration from a Markdown-first CMS, who needs to know exactly what a round trip preserves, normalizes, or degrades.
+
+## The contract
+
+### 1. Translation preserves semantics, not source spelling
+
+The first Markdown → Portable Text → Markdown pass normalizes Markdown to one canonical spelling: autolinks and reference links become inline links, indented code becomes fenced code, soft-wrapped lines join into one, and emphasis, headings, lists, and tables each get one canonical form.
+
+```md
+<https://portabletext.org>
+```
+
+parses and serializes back as:
+
+```md
+[https://portabletext.org](https://portabletext.org)
+```
+
+### 2. The normalized Markdown is a fixpoint
+
+The normalized Markdown is a fixpoint for plain text and for every construct in the [Supported features](/conversion/markdown-to-portable-text/#supported-features) table: parsing it and serializing again reproduces it byte-for-byte. Literal Markdown punctuation in a span's text is backslash-escaped when it serializes, so a second parse reads back the same characters instead of new markup.
+
+```ts
+import {
+  markdownToPortableText,
+  portableTextToMarkdown,
+} from '@portabletext/markdown'
+
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    style: 'normal',
+    children: [{_type: 'span', text: '*bar*', marks: []}],
+    markDefs: [],
+  },
+])
+// -> '\*bar\*'
+
+markdownToPortableText('\\*bar\\*')
+// -> span text back to '*bar*'
+```
+
+### 3. MD → PT survival is schema-driven
+
+Constructs whose type the schema doesn't declare degrade predictably: they keep their content and drop the structure that named them. A mark, list, or task checkbox whose type isn't in the schema keeps its text and drops the formatting.
+
+```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+
+const schema = compileSchema(defineSchema({})) // no 'strong' decorator declared
+
+markdownToPortableText('**bar**', {schema})
+// -> [{..., children: [{text: 'bar', marks: []}]}]
+```
+
+### 4. PT → MD degradation is predictable
+
+Portable Text structures with no Markdown form degrade predictably going back out. GFM tables have one header row, so header rows beyond the first flatten into the body.
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'table',
+    headerRows: 2,
+    rows: [
+      {
+        _type: 'row',
+        cells: [
+          {
+            _type: 'cell',
+            value: [
+              /* 'H1a' */
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'row',
+        cells: [
+          {
+            _type: 'cell',
+            value: [
+              /* 'H1b' */
+            ],
+          },
+        ],
+      },
+      {
+        _type: 'row',
+        cells: [
+          {
+            _type: 'cell',
+            value: [
+              /* 'data' */
+            ],
+          },
+        ],
+      },
+    ],
+  },
+])
+```
+
+```md
+| H1a  |
+| ---- |
+| H1b  |
+| data |
+```
+
+Deep or level-skipping list levels collapse to relative nesting: a list's first item renders at the top level whatever its `level`, and each deeper jump between items indents one step, however many levels it skips.
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    listItem: 'bullet',
+    level: 1,
+    children: [{_type: 'span', text: 'foo', marks: []}],
+  },
+  {
+    _type: 'block',
+    listItem: 'bullet',
+    level: 4,
+    children: [{_type: 'span', text: 'bar', marks: []}],
+  },
+  {
+    _type: 'block',
+    listItem: 'bullet',
+    level: 1,
+    children: [{_type: 'span', text: 'baz', marks: []}],
+  },
+])
+// -> '- foo\n   - bar\n- baz'
+```
+
+An unknown object type renders as a fenced JSON block. That block is not a stopgap spelling of the original type: on reparse it comes back as a `code` object, not the type that went out. Round-tripping an unrecognized type through Markdown is destructive.
+
+````ts
+portableTextToMarkdown([{_type: 'widget', _key: 'w1', color: 'blue'}])
+// -> '```json\n{\n  "_type": "widget",\n  "_key": "w1",\n  "color": "blue"\n}\n```'
+
+markdownToPortableText(/* the fenced block above */)
+// -> [{_type: 'code', language: 'json', code: '{\n  "_type": "widget",\n  "_key": "w1",\n  "color": "blue"\n}'}]
+// (a 'code' object, not the original 'widget' type)
+````
+
+### 5. Identity does not round-trip
+
+Keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    children: [
+      {_type: 'span', text: 'foo', marks: ['strong']},
+      {_type: 'span', text: 'bar', marks: ['strong']},
+    ],
+  },
+])
+// -> '**foobar**'
+
+markdownToPortableText('**foobar**')
+// -> one span, a new key, text: 'foobar', marks: ['strong']
+// (the two original spans and their keys are gone)
+```
+
+### 6. Hard breaks round-trip through a dedicated channel
+
+A `\n` inside a span's text and hard-break syntax (two or more trailing spaces, or a backslash, before the newline) are exclusive counterparts in both directions: a `\n` always renders as hard-break syntax on the way out, and hard-break syntax always becomes `\n` on the way in, never the space a soft wrap joins with.
+
+```ts
+markdownToPortableText('line one\nline two')
+// -> one span, text: 'line one line two' (soft wrap, joined with a space)
+
+markdownToPortableText('line one  \nline two')
+// -> one span, text: 'line one\nline two' (hard break, kept as \n)
+
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    children: [{_type: 'span', text: 'line one\nline two', marks: []}],
+  },
+])
+// -> 'line one  \nline two' (hard-break syntax)
+```
+
+## Exceptions
+
+Three named exceptions qualify the fixpoint claim in guarantee 2 above.
+
+**Linkified substrings.** An explicit-scheme URL or an email address in a span's text is never escaped: the text stays byte-identical, but it gains a `link` mark on the next parse (autolinking is a parser feature, not a round-trip bug).
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    children: [
+      {_type: 'span', text: 'Visit https://example.com now', marks: []},
+    ],
+  },
+])
+// -> 'Visit https://example.com now'
+
+markdownToPortableText('Visit https://example.com now')
+// -> three spans: 'Visit ' (no marks), 'https://example.com' (marks: ['<generated link key>']),
+//    ' now' (no marks); a 'link' markDef with href 'https://example.com'
+
+portableTextToMarkdown(/* the three-span result above */)
+// -> 'Visit [https://example.com](https://example.com) now'
+```
+
+The next serialization renders the now-marked span as the explicit inline link `[https://example.com](https://example.com)`, which is the stable form from that point on: reparsing and serializing again reproduces the same markdown byte-for-byte. The loop converges after one cycle, it never oscillates between the bare and linked spellings.
+
+Fuzzy `www.` forms follow the same unescaped-and-linkified path only while they carry no markdown-significant punctuation. Once one does, the punctuation takes normal escaping instead, the same as it would anywhere else in a span's text:
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    children: [
+      {_type: 'span', text: 'see www.example.com/*x* today', marks: []},
+    ],
+  },
+])
+// -> 'see www.example.com/\*x\* today'
+
+markdownToPortableText('see www.example.com/\\*x\\* today')
+// -> text back to 'see www.example.com/*x* today' (byte-identical), split across three spans:
+//    'see ' (no marks), 'www.example.com/' (marks: ['<generated link key>']), '*x* today' (no marks)
+```
+
+**Heading hard-break structural split.** A hard break inside a heading forces a structural split into a second block on reparse, since an ATX heading is single-line. The text itself still survives, split across the two blocks.
+
+```ts
+portableTextToMarkdown([
+  {
+    _type: 'block',
+    style: 'h1',
+    children: [{_type: 'span', text: 'foo\nbar', marks: []}],
+  },
+])
+// -> '# foo  \nbar' (hard-break syntax: two trailing spaces before the newline)
+
+markdownToPortableText('# foo  \nbar')
+// -> two blocks: {style: 'h1', children: [{text: 'foo'}]}, {style: 'normal', children: [{text: 'bar'}]}
+// (the span text survives, split across the two blocks; block identity doesn't)
+```
+
+**CommonMark-inherent whitespace trimming.** Leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint claim.
+
+```ts
+markdownToPortableText('  hello world  ')
+// -> span text: 'hello world' (no leading or trailing spaces)
+```
+
+## Further reading
+
+- [Markdown to Portable Text](/conversion/markdown-to-portable-text/) for parsing Markdown into PT blocks
+- [Markdown rendering](/rendering/markdown/) for rendering PT blocks as Markdown
+- [`@portabletext/markdown` on GitHub](https://github.com/portabletext/editor/tree/main/packages/markdown) for full API documentation and changelog

--- a/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
@@ -5,7 +5,7 @@ description: Convert Markdown strings into Portable Text blocks using @portablet
 
 import {PackageManagers} from 'starlight-package-managers'
 
-{/* The schema, matcher, and supported-features tables and the round-trip section mirror packages/markdown/README.md. Keep the twins in sync: a claim corrected in one place is stale in the other. */}
+{/* The schema, matcher, and supported-features tables mirror packages/markdown/README.md. Keep the twins in sync: a claim corrected in one place is stale in the other. The Round-trip behavior section is a summary; [Markdown round-tripping](/conversion/markdown-round-tripping/) is canonical. */}
 
 :::note[Prerequisites]
 This guide covers `@portabletext/markdown` **v1.x** ([changelog](https://github.com/portabletext/editor/releases)). No framework dependencies. Works in Node.js, Deno, edge runtimes, and browsers.
@@ -103,13 +103,7 @@ This package uses markdown-it as its Markdown parser. Remark and unified plugins
 
 ## Round-trip behavior
 
-Converting Markdown to Portable Text and back isn't a lossless mirror. Five things to expect:
-
-- Translation normalizes rather than preserves: a first Markdown → Portable Text → Markdown pass rewrites Markdown to one canonical spelling. Autolinks and reference links become inline links, indented code becomes fenced code, and `<https://portabletext.org>` comes back as `[https://portabletext.org](https://portabletext.org)`.
-- The normalized form is a fixpoint for the constructs in the table above, and for plain text: parsing it and serializing again reproduces it byte-for-byte, because literal Markdown punctuation in plain text is backslash-escaped on the way out (`*bar*` comes back as `\*bar\*`, which a second parse reads as the literal text). Three exceptions: an explicit-scheme URL or an email stays byte-identical but gains a `link` mark on the next parse (fuzzy `www.` forms stay unescaped only while they contain no markdown-significant punctuation); a hard break inside a heading forces a structural split into a second block on reparse, since an ATX heading is single-line (the text itself still survives, split across the two blocks); and leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint claim.
-- Unrecognized constructs degrade, they don't fail. A mark, list, or task checkbox whose type isn't in the schema keeps its text and drops the formatting: an undeclared `strong` decorator turns `**bar**` into a plain span reading `bar`.
-- Portable Text structures with no Markdown form degrade predictably going back out. GFM has one header row, so extra header rows flatten into the body; deep or level-skipping lists collapse to relative nesting; unknown object types render as a fenced JSON block.
-- Keys and span boundaries aren't identity: every parse regenerates block and span keys, and adjacent spans with identical marks merge.
+Converting Markdown to Portable Text and back isn't a lossless mirror: translation normalizes rather than preserves, and structures either side can't express degrade predictably rather than failing. See [Markdown round-tripping](/conversion/markdown-round-tripping/) for the full contract, worked examples, and the named exceptions (linkified substrings, heading hard breaks, whitespace trimming).
 
 ## Other conversion paths
 

--- a/apps/docs/src/content/docs/rendering/markdown.mdx
+++ b/apps/docs/src/content/docs/rendering/markdown.mdx
@@ -11,7 +11,7 @@ This guide covers `@portabletext/markdown` **v1.x** ([changelog](https://github.
 
 `@portabletext/markdown` renders Portable Text blocks as Markdown strings. Use it to generate Markdown for static site generators, README files, AI prompts, or any system that consumes Markdown.
 
-Looking to convert Markdown into Portable Text? See the [Markdown to Portable Text](/conversion/markdown-to-portable-text/) conversion guide, whose [Round-trip behavior](/conversion/markdown-to-portable-text/#round-trip-behavior) section covers what survives a Markdown → Portable Text → Markdown loop.
+Looking to convert Markdown into Portable Text? See the [Markdown to Portable Text](/conversion/markdown-to-portable-text/) conversion guide. For what survives a Markdown → Portable Text → Markdown loop, see [Markdown round-tripping](/conversion/markdown-round-tripping/).
 
 ## Install
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -81,34 +81,28 @@ const markdown = portableTextToMarkdown([
 
 ## Round-trip behavior
 
-1. Translation preserves semantics, not source spelling. The first MD→PT→MD pass normalizes Markdown to one canonical spelling: autolinks and reference links become inline links, indented code becomes fenced code, soft-wrapped lines join into one, and emphasis, headings, lists, and tables each get one canonical form.
+Converting Markdown to Portable Text and back isn't a lossless mirror:
 
-   ```
-   <https://portabletext.org>  ->  [https://portabletext.org](https://portabletext.org)
-   [ref link][id]              ->  [ref link](https://example.com "title")
-   ```
+1. Translation preserves semantics, not source spelling: the first MD→PT→MD pass normalizes Markdown to one canonical spelling (autolinks become inline links, indented code becomes fenced code, soft-wrapped lines join into one, and so on).
+2. The normalized Markdown is a fixpoint for plain text and the [Supported features](#supported-features) table: parsing it and serializing again reproduces it byte-for-byte.
+3. MD→PT survival is schema-driven: a construct whose type the schema doesn't declare keeps its content and drops the structure that named it.
+4. PT structures with no Markdown form degrade predictably on PT→MD (extra table header rows flatten into the body, deep or level-skipping lists collapse to relative nesting, unknown types render as a fenced JSON block).
+5. Identity does not round-trip: keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
+6. A hard break and a `\n` in a span's text are exclusive counterparts in both directions: a `\n` always renders as hard-break syntax on the way out, and hard-break syntax always becomes `\n` on the way in, never the space a soft wrap joins with.
 
-2. The normalized Markdown is a fixpoint for the constructs in the [Supported features](#supported-features) table above, and for plain text: parsing it and serializing again reproduces it byte-for-byte, pinned by a full-document round-trip test. Literal Markdown punctuation in plain text is backslash-escaped on serialization, so a second parse reads back the same characters instead of markup.
+Three exceptions to the fixpoint claim: an explicit-scheme URL or email keeps its text but gains a `link` mark on reparse, and a fuzzy `www.` form does too unless it carries markdown-significant punctuation; a hard break inside a heading splits into a second block on reparse, since an ATX heading is single-line; and leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint.
 
-   ```
-   *bar*  ->  \*bar\*  (escaped on serialization; a second parse reads back the literal text)
-   ```
-
-   Three exceptions. An explicit-scheme URL or an email is never escaped: text identity holds, but it gains a `link` mark on the next parse (autolinking is a parser feature, not a round-trip bug); fuzzy `www.` forms stay unescaped only while they contain no markdown-significant punctuation. A hard break inside a heading forces a structural split into a second block on reparse, since an ATX heading is single-line; the text itself still survives, split across the two blocks. And leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint claim.
-
-3. MD→PT survival is schema-driven. Constructs whose type the schema doesn't declare degrade predictably: they keep their content and drop the structure that named them. Marks drop formatting but keep the text (`**bar**` with no `strong` decorator in the schema becomes a plain span reading `bar`); tables flatten their cell content into top-level blocks; images fall back to their Markdown source as plain text; task-list checkboxes strip to plain list items.
-
-4. PT structures with no Markdown form degrade predictably on PT→MD. GFM tables have one header row, so header rows beyond the first flatten into the body. Deep or level-skipping lists collapse to relative nesting. A list's first item renders at the top level whatever its `level`, and each deeper jump between items indents one step, however many levels it skips. Multi-block table cells join their blocks with spaces. Unknown object types render as a fenced JSON block; unknown marks pass their text through unformatted.
-
-5. Identity does not round-trip. Keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
+See [Markdown round-tripping](https://www.portabletext.org/conversion/markdown-round-tripping/) on the docs site for the full contract and worked examples.
 
 ## Usage
 
-<!-- The schema table, matcher table, supported-features table, and
-     round-trip section have condensed twins on the docs site
+<!-- The schema table, matcher table, and supported-features table have
+     condensed twins on the docs site
      (apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx).
      Keep them in sync: a claim corrected in one place is stale in the
-     other. -->
+     other. The Round-trip behavior section above is a summary of
+     apps/docs/src/content/docs/conversion/markdown-round-tripping.mdx,
+     which is canonical; keep the two in sync the same way. -->
 
 ### `markdownToPortableText`
 


### PR DESCRIPTION
Evaluating `@portabletext/markdown` for a markdown-based pipeline starts with one question: what survives the loop? The answer lived as twin sections in the package README and the conversion page, sized for asides, and the two had already drifted once (the README carried two degradations the site section lacked). This PR gives the contract a canonical home.

The new page, Conversion → Markdown round-tripping, states six guarantees, each with a worked example executed against the built package: semantics-not-spelling normalization, the byte-for-byte fixpoint for supported constructs and plain text, schema-driven degradation on the way in, predictable degradation on the way out (now stating plainly that an unknown `_type` round-trips destructively into a `code` block, and that deep list levels collapse), key regeneration and span merging, and the hard-break channel (`\n` in span text and hard-break syntax are exclusive counterparts in both directions), promoted from exception to guarantee. Three genuine exceptions qualify the fixpoint: linkified substrings (with the convergence loop stated: a bare URL becomes text plus a link mark, then the explicit inline link, stable from there), the heading hard-break split (shown from the PT side, where it actually originates), and CommonMark whitespace trimming.

The twins demote to summaries that link the canonical page, and the keep-in-sync comments name all three files. A cold read caught one false example before it shipped: the fuzzy-`www.` claim was illustrated in the direction where it does not hold; it now shows the serialization direction it was about, verified like every other example on the page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and navigation only; no library or runtime behavior changes.
> 
> **Overview**
> Adds **Conversion → Markdown round-tripping** as the canonical docs page for `@portabletext/markdown` MD↔PT behavior: six guarantees (normalization, fixpoint, schema-driven MD→PT loss, predictable PT→MD loss including destructive unknown-type JSON fallback, non-round-tripping identity, hard-break channel) plus three fixpoint exceptions, each with worked examples.
> 
> The long **Round-trip behavior** sections in `markdown-to-portable-text.mdx` and `packages/markdown/README.md` shrink to summaries that link here; **Markdown rendering** cross-links the new page instead of the conversion guide anchor. Sidebar and sync comments now treat three files as the round-trip source of truth so README and site twins stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 110b1cadc3207e50841160cace293eee5d30a85d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->