### PR TITLE
feat: report degraded constructs during markdown parsing

### DIFF
--- a/.changeset/report-degraded-conversions.md
+++ b/.changeset/report-degraded-conversions.md
@@ -1,0 +1,38 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: report degraded constructs during markdown parsing
+
+`markdownToPortableText` now takes an `onDegradation` option for constructs the schema can't represent (an undeclared decorator, a table with no `table` block object, a task checkbox with no `task` list, and so on). One callback, called at most once, after the whole document has been walked, only when at least one construct degraded: a `report` object holding `degradations`, every `Degradation` in encounter order (`{type: string, message: string, line?: number, snippet?: string}`, exported as `Degradation`, with `type` a literal union that grows as new degradation sites report; `snippet` is the offending construct's text, truncated to 40 characters, present whenever there's a specific piece of source text to quote), and `message`, the same degradations grouped, snippeted, and sorted by line into one human-readable string.
+
+```ts
+const blocks = markdownToPortableText('**a**', {
+  schema: compileSchema(defineSchema({})),
+  onDegradation: (report) => console.log(report),
+})
+// blocks: a plain span reading `a`, the `strong` formatting dropped
+// report: {
+//   degradations: [{type: 'decorator-dropped', message: 'Removed bold formatting, kept the text: the schema has no `strong` decorator', line: 1, snippet: 'a'}],
+//   message: 'Markdown could not be converted without loss:\n- line 1: Removed bold formatting, kept the text: the schema has no `strong` decorator ("a")',
+// }
+```
+
+Enforce against lossy output by throwing your own error from inside the callback; the throw propagates out of `markdownToPortableText`:
+
+```ts
+markdownToPortableText('**a**\n\n**b**\n\n| x |\n| - |\n| y |', {
+  schema: compileSchema(defineSchema({})),
+  onDegradation: ({message}) => {
+    throw new Error(message)
+  },
+})
+// throws Error:
+// Markdown could not be converted without loss:
+// - Removed bold formatting, kept the text: the schema has no `strong` decorator (2×: "a", "b")
+// - line 5: Table became plain text blocks, rows and columns lost: the schema has no `table` block object
+```
+
+Repeated declines of the same kind collapse into one line of `message` instead of repeating the sentence once per occurrence; `degradations` stays ungrouped, one entry per occurrence. Match on `type`: `message` is human-readable and may change between releases.
+
+With `onDegradation` unset, conversion still degrades silently: a library shouldn't log on its own initiative. This removes the previous behavior of a handful of style-fallback paths calling `console.warn` on their own; pass a function to `onDegradation` to observe those losses instead.

--- a/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-to-portable-text.mdx
@@ -101,6 +101,10 @@ Override a matcher when your schema uses a different name for a type (say, `'hea
 This package uses markdown-it as its Markdown parser. Remark and unified plugins are not compatible.
 :::
 
+## Reporting degradation
+
+A construct the schema can't represent (an undeclared decorator, a table with no `table` block object, and so on) degrades to a lossier shape by default rather than failing, silently: nothing reaches the console. `onDegradation` covers what an import pipeline or an agent that can't afford to lose content silently needs: a function is called once, after the whole document has been walked, only when at least one construct degraded, with every `Degradation` (`type`, `message`, `line` when available, `snippet` when there's source text to quote) in encounter order and a canonical grouped `message`, to observe the losses. Enforce against them by throwing your own error from inside that callback instead of returning lossy Portable Text; the throw propagates out of `markdownToPortableText`. The [package README](https://github.com/portabletext/editor/tree/main/packages/markdown#reporting-degradation) has the full option shape, an enforce example, and the report object's fields.
+
 ## Round-trip behavior
 
 Converting Markdown to Portable Text and back isn't a lossless mirror: translation normalizes rather than preserves, and structures either side can't express degrade predictably rather than failing. See [Markdown round-tripping](/conversion/markdown-round-tripping/) for the full contract, worked examples, and the named exceptions (linkified substrings, heading hard breaks, whitespace trimming).

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -415,6 +415,39 @@ markdownToPortableText(markdown, {
 })
 ```
 
+#### Reporting degradation
+
+Every construct the schema can't represent (a decorator not in the schema, a table with no `table` block object, a task checkbox with no `task` list, and so on) degrades to a lossier shape rather than throwing. A ` ```json:object ` fence or tagged code span that fails to reconstruct (invalid JSON, or no string `_type`) reports too, as `object-carrier-invalid`, even on a schema that would otherwise accept everything: it's the payload that's unusable, not the schema. `onDegradation` observes both, one callback covering all uses. Left unset, the conversion stays silent and returns the lossiest representation it can build, since a library shouldn't log on its own initiative. Passed a function, observe the losses: it's called once, after the whole document has been walked, only when at least one construct degraded, with a report object holding every `Degradation` in encounter order and a canonical grouped `message`. Enforce against lossy output by throwing your own error from inside that callback; the throw propagates out of `markdownToPortableText`.
+
+```ts
+markdownToPortableText(markdown, {
+  onDegradation: ({degradations, message}) => {
+    // degradations: every Degradation, in encounter order
+    // message: the same degradations grouped, snippeted, and sorted by line
+    logger.warn(message)
+  },
+})
+```
+
+Each `Degradation` carries `type`, a human-readable `message`, `line` when a source line is available, and `snippet` (the offending construct's text, truncated to 40 characters) when there's a specific piece of source text to quote. Match on `type`, not `message`: the type is the stable contract, the message can change between releases.
+
+Enforcing means throwing your own error from inside the callback:
+
+```ts
+markdownToPortableText('# heading\n\n**bold**', {
+  schema: compileSchema(defineSchema({})),
+  onDegradation: ({message}) => {
+    throw new Error(message)
+  },
+})
+// throws Error:
+// Markdown could not be converted without loss:
+// - line 1: `#` heading became a normal paragraph: the schema has no `h1` style ("heading")
+// - line 3: Removed bold formatting, kept the text: the schema has no `strong` decorator ("bold")
+```
+
+Repeated declines of the same kind (the same missing decorator on three spans, say) collapse into one line of `message` instead of repeating the sentence: `- Removed bold formatting, kept the text: the schema has no \`strong\` decorator (3×: "a", "b", "c")`. `degradations` stays ungrouped, one entry per occurrence.
+
 ### `portableTextToMarkdown`
 
 ```ts

--- a/packages/markdown/src/index.ts
+++ b/packages/markdown/src/index.ts
@@ -45,6 +45,7 @@ export type {
   PortableTextTypeRendererOptions,
 } from './from-portable-text/types'
 export {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
+export type {Degradation} from './to-portable-text/markdown-to-portable-text'
 export type {
   AnnotationMatcher,
   DecoratorMatcher,

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -4,11 +4,26 @@ import {
   type BlockObjectDefinition,
 } from '@portabletext/schema'
 import {createTestKeyGenerator, getTersePt} from '@portabletext/test'
-import {describe, expect, test} from 'vitest'
-import {defaultSchema} from './default-schema'
+import {describe, expect, test, vi} from 'vitest'
+import {defaultCalloutObjectDefinition, defaultSchema} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
-import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
+import {
+  markdownToPortableText,
+  type Degradation,
+} from './to-portable-text/markdown-to-portable-text'
 import {buildObjectMatcher} from './to-portable-text/matchers'
+
+/**
+ * Strips `_key` from a Portable Text tree before comparing two conversions
+ * that use independent key generators (a structural decline against the
+ * flat path it's supposed to mirror, say): the keys are never equal, only
+ * the structure needs to be.
+ */
+function omitKeys<T>(value: T): T {
+  return JSON.parse(
+    JSON.stringify(value, (key, val) => (key === '_key' ? undefined : val)),
+  )
+}
 
 describe(markdownToPortableText.name, () => {
   test('empty string', () => {
@@ -6678,6 +6693,2843 @@ describe(markdownToPortableText.name, () => {
           _key: 'k0',
           code: '[{"_type": "product"}]',
           language: 'json:object',
+        },
+      ])
+    })
+  })
+  describe('degradation report', () => {
+    type DegradationReport = {
+      degradations: Array<Degradation>
+      message: string
+    }
+
+    test('dropped decorator: undeclared `strong` decorator', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('**foo**', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'decorator-dropped',
+          message:
+            'Removed bold formatting, kept the text: the schema has no `strong` decorator',
+          line: 1,
+          snippet: 'foo',
+        },
+      ])
+    })
+
+    test('style fallback: undeclared `h1` heading falls back to `normal`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('# foo', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({styles: [{name: 'normal'}]})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation.mock.calls).toEqual([
+        [
+          {
+            degradations: [
+              {
+                type: 'style-fallback',
+                message:
+                  '`#` heading became a normal paragraph: the schema has no `h1` style',
+                line: 1,
+                snippet: 'foo',
+              },
+            ],
+            message: [
+              'Markdown could not be converted without loss:',
+              '- line 1: `#` heading became a normal paragraph: the schema has no `h1` style ("foo")',
+            ].join('\n'),
+          },
+        ],
+      ])
+    })
+
+    test('table flattened: undeclared `table` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = ['| a | b |', '| - | - |', '| 1 | 2 |'].join('\n')
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'a', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k3',
+          children: [{_type: 'span', _key: 'k4', text: 'b', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k7',
+          children: [{_type: 'span', _key: 'k8', text: '1', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k10',
+          children: [{_type: 'span', _key: 'k11', text: '2', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'table-flattened',
+          message:
+            'Table became plain text blocks, rows and columns lost: the schema has no `table` block object',
+          line: 1,
+        },
+      ])
+    })
+
+    test('task checkbox stripped: undeclared `task` list', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('- [x] foo', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({lists: [{name: 'bullet'}]})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+          listItem: 'bullet',
+          level: 1,
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'task-checkbox-stripped',
+          message:
+            'Removed the `[x]` checkbox, kept a plain list item: the schema has no `task` list',
+          line: 1,
+          snippet: 'foo',
+        },
+      ])
+    })
+
+    test('pure task list on a task-only schema: nothing reported, `bullet_list_open` defers the verdict to item resolution', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      const result = markdownToPortableText(
+        ['- [x] foo', '- [ ] bar'].join('\n'),
+        {
+          keyGenerator: createTestKeyGenerator(),
+          schema: compileSchema(defineSchema({lists: [{name: 'task'}]})),
+          onDegradation,
+        },
+      )
+
+      expect(result).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+          listItem: 'task',
+          level: 1,
+          checked: true,
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+          listItem: 'task',
+          level: 1,
+          checked: false,
+        },
+      ])
+
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('code fence to text: undeclared `code` type names the language', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = ['```js', 'code', '```'].join('\n')
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'code', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'code-block-to-text',
+          message:
+            '`js` code block became plain text: the schema has no `code` block object',
+          line: 1,
+          snippet: 'code',
+        },
+      ])
+    })
+
+    test('multiple degradations arrive in encounter order with their token-map lines, in one callback invocation', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = [
+        '# foo',
+        '',
+        '**bar**',
+        '',
+        '```js',
+        'code',
+        '```',
+      ].join('\n')
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k4',
+          children: [{_type: 'span', _key: 'k5', text: 'code', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]).toEqual({
+        degradations: [
+          {
+            type: 'style-fallback',
+            message:
+              '`#` heading became a normal paragraph: the schema has no `h1` style',
+            line: 1,
+            snippet: 'foo',
+          },
+          {
+            type: 'decorator-dropped',
+            message:
+              'Removed bold formatting, kept the text: the schema has no `strong` decorator',
+            line: 3,
+            snippet: 'bar',
+          },
+          {
+            type: 'code-block-to-text',
+            message:
+              '`js` code block became plain text: the schema has no `code` block object',
+            line: 5,
+            snippet: 'code',
+          },
+        ],
+        message: [
+          'Markdown could not be converted without loss:',
+          '- line 1: `#` heading became a normal paragraph: the schema has no `h1` style ("foo")',
+          '- line 3: Removed bold formatting, kept the text: the schema has no `strong` decorator ("bar")',
+          '- line 5: `js` code block became plain text: the schema has no `code` block object ("code")',
+        ].join('\n'),
+      })
+    })
+
+    test('nested blockquote declines report in encounter order (innermost closes first)', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'blockquote',
+              fields: [{name: 'content', type: 'array'}],
+            },
+          ],
+        }),
+      )
+
+      markdownToPortableText('> foo\n>> bar', {
+        keyGenerator,
+        schema,
+        types: {blockquote: () => undefined},
+        onDegradation,
+      })
+
+      // The inner blockquote (line 2) closes before the outer one (line 1),
+      // so `degradations` sees line 2 first: closing order, not document order.
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 2,
+        },
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+      ])
+    })
+
+    test('a consumer throw groups same-message declines and lists their lines top-to-bottom, despite reverse encounter order', () => {
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'blockquote',
+              fields: [{name: 'content', type: 'array'}],
+            },
+          ],
+        }),
+      )
+
+      expect(() =>
+        markdownToPortableText('> foo\n>> bar', {
+          keyGenerator: createTestKeyGenerator(),
+          schema,
+          types: {blockquote: () => undefined},
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          '- Blockquote became normal paragraphs: the schema has no `blockquote` style (2\u00d7: lines 1, 2)',
+        ].join('\n'),
+      )
+    })
+
+    test('`onDegradation` fires at most once, and only when something degraded', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo **bar** baz', {
+          keyGenerator: createTestKeyGenerator(),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: 'foo ', marks: []},
+            {_type: 'span', _key: 'k2', text: 'bar', marks: ['strong']},
+            {_type: 'span', _key: 'k3', text: ' baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+      expect(onDegradation).not.toHaveBeenCalled()
+
+      markdownToPortableText('**bar**\n\n**baz**', {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+    })
+
+    test('`onDegradation` not set: conversion degrades silently, nothing reaches `console.warn`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const consoleWarnSpy = vi
+        .spyOn(console, 'warn')
+        .mockImplementation(() => {})
+
+      markdownToPortableText('**bold**', {
+        keyGenerator,
+        schema: compileSchema(defineSchema({})),
+      })
+
+      expect(consoleWarnSpy).not.toHaveBeenCalled()
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('horizontal rule to text: undeclared `horizontal-rule` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('---', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: '---', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'horizontal-rule-to-text',
+          message:
+            'Horizontal rule became the text `---`: the schema has no `horizontal-rule` block object',
+          line: 1,
+        },
+      ])
+    })
+
+    test('HTML block to text: undeclared `html` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('<div>Content</div>', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: '<div>Content</div>', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'html-block-to-text',
+          message:
+            'HTML block became plain text: the schema has no `html` block object',
+          line: 1,
+          snippet: '<div>Content</div>',
+        },
+      ])
+    })
+
+    test('indented code to text: undeclared `code` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('    const foo = "bar"', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: 'const foo = "bar"',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'code-block-to-text',
+          message:
+            'Code block became plain text: the schema has no `code` block object',
+          line: 1,
+          snippet: 'const foo = "bar"',
+        },
+      ])
+    })
+
+    test('inline HTML dropped: default `skip` mode', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo <br/> bar', {
+          keyGenerator,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo  bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'inline-html-dropped',
+          message:
+            'Removed inline HTML tags, kept nothing: `html.inline` is `skip` (the default)',
+          line: 1,
+          snippet: '<br/>',
+        },
+      ])
+    })
+
+    test('inline HTML in `text` mode: no degradation, no event', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo <br/> bar', {
+          keyGenerator,
+          html: {inline: 'text'},
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: 'foo <br/> bar', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('image to text: standalone image, undeclared `image` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('![alt](src.png)', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: '![alt](src.png)', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-to-text',
+          message:
+            'Image became its markdown source as plain text: the schema has no `image` object',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('image to text: inline-position image, undeclared `image` type', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo ![alt](src.png) bar', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {
+              _type: 'span',
+              _key: 'k1',
+              text: 'foo ![alt](src.png) bar',
+              marks: [],
+            },
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-to-text',
+          message:
+            'Image became its markdown source as plain text: the schema has no `image` object',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('image demoted to inline: standalone image, `image` declared only as an inline object', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          inlineObjects: [
+            {
+              name: 'image',
+              fields: [
+                {name: 'src', type: 'string'},
+                {name: 'alt', type: 'string'},
+                {name: 'title', type: 'string'},
+              ],
+            },
+          ],
+        }),
+      )
+
+      expect(
+        markdownToPortableText('![alt](src.png)', {
+          keyGenerator: createTestKeyGenerator(),
+          schema,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          children: [{_key: 'k1', _type: 'image', src: 'src.png', alt: 'alt'}],
+          markDefs: [],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-block-to-inline',
+          message:
+            'The image became inline: the schema has no block-level `image`',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('image promoted to block: inline-position image, `image` declared only as a block object', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'image',
+              fields: [
+                {name: 'src', type: 'string'},
+                {name: 'alt', type: 'string'},
+                {name: 'title', type: 'string'},
+              ],
+            },
+          ],
+        }),
+      )
+
+      expect(
+        markdownToPortableText('foo ![alt](src.png) bar', {
+          keyGenerator: createTestKeyGenerator(),
+          schema,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k1', text: 'foo ', marks: []}],
+          markDefs: [],
+        },
+        {_key: 'k2', _type: 'image', src: 'src.png', alt: 'alt'},
+        {
+          _type: 'block',
+          _key: 'k3',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k4', text: ' bar', marks: []}],
+          markDefs: [],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-inline-to-block',
+          message:
+            'The image became its own block, splitting the paragraph: the schema has no inline `image`',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('image lifted back to block: standalone image inside a table cell', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = [
+        '| a | b |',
+        '| - | - |',
+        '| 1 | ![alt](src.png) |',
+      ].join('\n')
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _key: 'k14',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k6',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'a', marks: []},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'k5',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k4', text: 'b', marks: []},
+                      ],
+                      _key: 'k3',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k13',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k9',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k8', text: '1', marks: []},
+                      ],
+                      _key: 'k7',
+                      markDefs: [],
+                    },
+                  ],
+                },
+                {
+                  _type: 'cell',
+                  _key: 'k12',
+                  value: [
+                    {_key: 'k11', _type: 'image', src: 'src.png', alt: 'alt'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      // The default schema declares `image` in both `blockObjects` and
+      // `inlineObjects`, so the sole-image cell round-trips to the
+      // canonical block-level shape without loss.
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('image lifted back to block: standalone image inside a table cell, schema has no block-level `image`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      // `image` only exists as an inline object, so the standalone-image
+      // site's block attempt declines before its inline fallback matches.
+      const schema = compileSchema(
+        defineSchema({
+          ...defaultSchema,
+          blockObjects: defaultSchema.blockObjects.filter(
+            (blockObject) => blockObject.name !== 'image',
+          ),
+        }),
+      )
+      const markdown = ['| a |', '| - |', '| ![alt](src.png) |'].join('\n')
+
+      const result = markdownToPortableText(markdown, {
+        keyGenerator,
+        schema,
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _key: 'k8',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k3',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'a', marks: []},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k7',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k6',
+                  value: [
+                    {_key: 'k5', _type: 'image', src: 'src.png', alt: 'alt'},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      // The cell holds nothing but the image, so `td_close`'s sole-image
+      // lift recovers the canonical block-level shape: reporting the
+      // intermediate inline demotion would be a false positive.
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('image demoted, not lifted: mixed cell content, schema has no block-level `image`', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          ...defaultSchema,
+          blockObjects: defaultSchema.blockObjects.filter(
+            (blockObject) => blockObject.name !== 'image',
+          ),
+        }),
+      )
+      const markdown = ['| a |', '| - |', '| foo ![alt](src.png) |'].join('\n')
+
+      const result = markdownToPortableText(markdown, {
+        keyGenerator,
+        schema,
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _key: 'k9',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k3',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'a', marks: []},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k8',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k7',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k5', text: 'foo ', marks: []},
+                        {
+                          _key: 'k6',
+                          _type: 'image',
+                          src: 'src.png',
+                          alt: 'alt',
+                        },
+                      ],
+                      _key: 'k4',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      // The image sits alongside text, so the standalone-image site never
+      // runs at all: the inline image is the correct, lossless shape here,
+      // whether the schema has a block-level `image` or not, and the
+      // sole-image lift never gets a chance to apply. Contrast with the
+      // sole-image case above: matching schema, no `inTableCell` deferral
+      // masks a genuine event when the cell actually mixes content.
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('image not lifted back: mixed cell content with `image` declared only as a block object', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      // `table` is already a block object on the default schema; only
+      // `image` is trimmed down to a block-only object here.
+      const schema = compileSchema(
+        defineSchema({
+          ...defaultSchema,
+          inlineObjects: defaultSchema.inlineObjects.filter(
+            (inlineObject) => inlineObject.name !== 'image',
+          ),
+        }),
+      )
+      const markdown = ['| a |', '| - |', '| foo ![alt](src.png) |'].join('\n')
+
+      const result = markdownToPortableText(markdown, {
+        keyGenerator,
+        schema,
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _key: 'k9',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k3',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'a', marks: []},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k8',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k7',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k5', text: 'foo ', marks: []},
+                        {
+                          _key: 'k6',
+                          _type: 'image',
+                          src: 'src.png',
+                          alt: 'alt',
+                        },
+                      ],
+                      _key: 'k4',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-block-to-inline',
+          message:
+            "The image became inline: a table cell can't hold a block-level `image`",
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('image not lifted back: mixed cell content reports dropped fields too', () => {
+      // Same shape as the sibling test above, but the schema's block-only
+      // `image` declares only `src`, so the demoted image also drops `alt`.
+      // The demotion site must report that loss like every other
+      // accepted-object site does.
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {name: 'image', fields: [{name: 'src', type: 'string'}]},
+            defaultSchema.blockObjects.find(
+              (blockObject) => blockObject.name === 'table',
+            )!,
+          ],
+        }),
+      )
+      const markdown = [
+        '| a |',
+        '| - |',
+        '| foo ![my alt](https://x.co/i.png) |',
+      ].join('\n')
+
+      const result = markdownToPortableText(markdown, {
+        keyGenerator,
+        schema,
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _key: 'k9',
+          _type: 'table',
+          headerRows: 1,
+          rows: [
+            {
+              _key: 'k3',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'a', marks: []},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+            {
+              _key: 'k8',
+              _type: 'row',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k7',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'span', _key: 'k5', text: 'foo ', marks: []},
+                        {
+                          _key: 'k6',
+                          _type: 'image',
+                          src: 'https://x.co/i.png',
+                        },
+                      ],
+                      _key: 'k4',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'fields-dropped',
+          message:
+            "Dropped `alt` from `image`: not in the schema's `image` fields",
+          line: 1,
+        },
+        {
+          type: 'image-block-to-inline',
+          message:
+            "The image became inline: a table cell can't hold a block-level `image`",
+          line: 1,
+          snippet: 'https://x.co/i.png',
+        },
+      ])
+    })
+
+    test('heading inside a callout keeps its own style, no `blockquote` style-fallback fires', () => {
+      // The callout's own content style (`blockquote`, absent here) only
+      // degrades if a committing block actually took it. A heading commits
+      // with its own `h1` style, so nothing here needed the fallback.
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}, {name: 'h1'}],
+          blockObjects: [defaultCalloutObjectDefinition],
+        }),
+      )
+
+      expect(
+        markdownToPortableText('> [!NOTE]\n> # foo', {
+          keyGenerator,
+          schema,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'callout',
+          _key: 'k2',
+          tone: 'note',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'h1',
+              children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('plain text inside a callout still fires the `blockquote` style-fallback', () => {
+      // Contrast to the heading case above: a plain paragraph DOES take the
+      // declined `blockquote` style, so the fallback still fires.
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}, {name: 'h1'}],
+          blockObjects: [defaultCalloutObjectDefinition],
+        }),
+      )
+
+      expect(
+        markdownToPortableText('> [!NOTE]\n> plain text', {
+          keyGenerator,
+          schema,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'callout',
+          _key: 'k2',
+          tone: 'note',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              children: [
+                {_type: 'span', _key: 'k1', text: 'plain text', marks: []},
+              ],
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+      ])
+    })
+
+    test('a heading falling back to `normal` on its own does not also trigger the callout content style fallback', () => {
+      // Both the callout's own content style and the heading's `h1` style
+      // decline to the same `normal` fallback here: two independent
+      // declines landing on the same value, not one causing the other. The
+      // heading never touches `currentBlockquoteStyle`, so only its own
+      // `h1` fallback should fire.
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}],
+          blockObjects: [defaultCalloutObjectDefinition],
+        }),
+      )
+
+      expect(
+        markdownToPortableText('> [!NOTE]\n> # foo', {
+          keyGenerator,
+          schema,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'callout',
+          _key: 'k2',
+          tone: 'note',
+          content: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+              markDefs: [],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            '`#` heading became a normal paragraph: the schema has no `h1` style',
+          line: 2,
+          snippet: 'foo',
+        },
+      ])
+    })
+
+    test('callout fallback: undeclared `callout` type names the tone and the content style it fell back to', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      // The `> [!NOTE]` marker sits on line 1; only the callout's content
+      // (`baz`) is on line 2.
+      const markdown = ['> [!NOTE]', '> baz'].join('\n')
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'baz', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      // No `blockquote` style declared, so the content falls back to
+      // `normal`; the callout message names that, not `blockquote`, which
+      // is what the content was actually styled as.
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+        {
+          type: 'callout-fallback',
+          message:
+            '`[!NOTE]` callout became normal-styled text: the schema has no `callout` block object',
+          line: 1,
+        },
+      ])
+    })
+
+    test('callout fallback: neither `blockquote` nor `normal` style declared, both fallbacks reported', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = ['> [!NOTE]', '> baz'].join('\n')
+
+      const result = markdownToPortableText(markdown, {
+        keyGenerator,
+        schema: compileSchema(defineSchema({})),
+        block: {normal: () => undefined},
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'baz', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 1,
+        },
+        {
+          type: 'callout-fallback',
+          message:
+            '`[!NOTE]` callout became normal-styled text: the schema has no `callout` block object',
+          line: 1,
+        },
+      ])
+    })
+
+    test('fields dropped: accepted `callout` whose schema fields omit `content` destroys the body', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {name: 'callout', fields: [{name: 'tone', type: 'string'}]},
+          ],
+          styles: [{name: 'normal'}, {name: 'blockquote'}],
+        }),
+      )
+
+      const result = markdownToPortableText(
+        ['> [!NOTE]', '> body'].join('\n'),
+        {
+          keyGenerator: createTestKeyGenerator(),
+          schema,
+          onDegradation,
+        },
+      )
+
+      expect(result).toEqual([{_key: 'k2', _type: 'callout', tone: 'note'}])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'fields-dropped',
+          message:
+            "Dropped `content` from `callout`: not in the schema's `callout` fields",
+          line: 1,
+        },
+      ])
+    })
+
+    test('accepted callout with no `blockquote` style but no text content either: nothing reported', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'callout',
+              fields: [
+                {name: 'tone', type: 'string'},
+                {name: 'content', type: 'array'},
+              ],
+            },
+            {
+              name: 'image',
+              fields: [
+                {name: 'src', type: 'string'},
+                {name: 'alt', type: 'string'},
+              ],
+            },
+          ],
+        }),
+      )
+
+      const result = markdownToPortableText(
+        ['> [!WARNING]', '> ![foo](u)'].join('\n'),
+        {keyGenerator: createTestKeyGenerator(), schema, onDegradation},
+      )
+
+      expect(result).toEqual([
+        {
+          _key: 'k2',
+          _type: 'callout',
+          tone: 'warning',
+          content: [{_key: 'k1', _type: 'image', src: 'u', alt: 'foo'}],
+        },
+      ])
+
+      // No `blockquote` style declared, but nothing inside the callout ever
+      // needed one: its only content is a standalone image, which never
+      // creates a text block. Reporting the pending style fallback here
+      // would name a paragraph that never existed.
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('fields dropped: accepted `image` whose schema fields omit `alt` and `title` names both', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {name: 'image', fields: [{name: 'src', type: 'string'}]},
+          ],
+        }),
+      )
+
+      const result = markdownToPortableText('![alt text](src.png "a title")', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        onDegradation,
+      })
+
+      expect(result).toEqual([{_key: 'k1', _type: 'image', src: 'src.png'}])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'fields-dropped',
+          message:
+            "Dropped `alt`, `title` from `image`: not in the schema's `image` fields",
+          line: 1,
+        },
+      ])
+    })
+
+    test('style fallback: heading and `normal` both undeclared reports both, not a silent literal fallback', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('# foo', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          block: {normal: () => undefined},
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            '`#` heading became a normal paragraph: the schema has no `h1` style',
+          line: 1,
+          snippet: 'foo',
+        },
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 1,
+        },
+      ])
+    })
+
+    test('style fallback: blockquote and `normal` both undeclared reports both, not a silent literal fallback', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('> foo', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          block: {normal: () => undefined},
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 1,
+        },
+      ])
+    })
+
+    test('style fallback: structural-list paragraph with `normal` undeclared', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      const result = markdownToPortableText(['- foo', '', '  bar'].join('\n'), {
+        keyGenerator,
+        schema: compileSchema(
+          defineSchema({
+            blockObjects: [
+              {name: 'list', fields: [{name: 'items', type: 'array'}]},
+            ],
+          }),
+        ),
+        types: {
+          list: ({value, context}) => ({
+            _type: 'list',
+            _key: context.keyGenerator(),
+            kind: value.kind,
+            items: value.items,
+          }),
+        },
+        block: {normal: () => undefined},
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _type: 'list',
+          _key: 'k5',
+          kind: 'bullet',
+          items: [
+            {
+              _type: 'list-item',
+              _key: 'k0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'k1',
+                  children: [
+                    {_type: 'span', _key: 'k2', text: 'foo', marks: []},
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+                {
+                  _type: 'block',
+                  _key: 'k3',
+                  children: [
+                    {_type: 'span', _key: 'k4', text: 'bar', marks: []},
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      // Two paragraphs in the same list item, one style-fallback event
+      // each, since the structural-list `paragraph_open` path used to fall
+      // back to the literal `'normal'` without reporting.
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 1,
+        },
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 3,
+        },
+      ])
+    })
+
+    test('style fallback: standalone inline image in a structural list with `normal` undeclared', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      const result = markdownToPortableText('- ![alt](src.png)', {
+        keyGenerator,
+        schema: compileSchema(
+          defineSchema({
+            blockObjects: [
+              {name: 'list', fields: [{name: 'items', type: 'array'}]},
+            ],
+          }),
+        ),
+        types: {
+          list: ({value, context}) => ({
+            _type: 'list',
+            _key: context.keyGenerator(),
+            kind: value.kind,
+            items: value.items,
+          }),
+          image: ({value, isInline}) =>
+            isInline
+              ? {_type: 'image', _key: 'img', src: value.src, alt: value.alt}
+              : undefined,
+        },
+        block: {normal: () => undefined},
+        onDegradation,
+      })
+
+      expect(result).toEqual([
+        {
+          _type: 'list',
+          _key: 'k2',
+          kind: 'bullet',
+          items: [
+            {
+              _type: 'list-item',
+              _key: 'k0',
+              content: [
+                {
+                  _type: 'block',
+                  _key: 'k1',
+                  children: [
+                    {_type: 'image', _key: 'img', src: 'src.png', alt: 'alt'},
+                  ],
+                  markDefs: [],
+                  style: 'normal',
+                },
+              ],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'style-fallback',
+          message: 'Fell back to `normal` style: `normal` not in schema',
+          line: 1,
+        },
+        {
+          type: 'image-block-to-inline',
+          message:
+            'The image became inline: the schema has no block-level `image`',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
+    })
+
+    test('lossless structural list decline: schema has every list kind the content needs, nothing reported', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {name: 'list', fields: [{name: 'items', type: 'array'}]},
+          ],
+          lists: [{name: 'bullet'}, {name: 'task'}],
+        }),
+      )
+
+      const declined = markdownToPortableText('- [x] foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {list: () => undefined},
+        onDegradation,
+      })
+
+      const neverRegistered = markdownToPortableText('- [x] foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      // The decline's only visible effect is losing the `list` container
+      // wrapper; every item still resolves through the schema's `task`
+      // list, so the flat fallback is lossless and reports nothing.
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k1',
+          children: [{_type: 'span', _key: 'k2', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+          listItem: 'task',
+          level: 1,
+          checked: true,
+        },
+      ])
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('structural list decline on a taskless schema mirrors the flat path: bullet fallback, not dropped structure', () => {
+      const declineDegradation = vi.fn<(report: DegradationReport) => void>()
+      const flatDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {name: 'list', fields: [{name: 'items', type: 'array'}]},
+          ],
+          lists: [{name: 'bullet'}],
+        }),
+      )
+
+      const declined = markdownToPortableText('- [x] foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {list: () => undefined},
+        onDegradation: declineDegradation,
+      })
+
+      const neverRegistered = markdownToPortableText('- [x] foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        onDegradation: flatDegradation,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k1',
+          children: [{_type: 'span', _key: 'k2', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+          listItem: 'bullet',
+          level: 1,
+        },
+      ])
+
+      const expectedDegradations = [
+        {
+          type: 'task-checkbox-stripped',
+          message:
+            'Removed the `[x]` checkbox, kept a plain list item: the schema has no `task` list',
+          line: 1,
+          snippet: 'foo',
+        },
+      ]
+      expect(declineDegradation.mock.calls[0]![0]!.degradations).toEqual(
+        expectedDegradations,
+      )
+      expect(flatDegradation.mock.calls[0]![0]!.degradations).toEqual(
+        expectedDegradations,
+      )
+    })
+
+    test('structural list decline keeps a nested blockquote as its own block, mirrors the flat path style boundary', () => {
+      // A bare style-equality gate would let the callout's `blockquote`
+      // paragraph merge into the preceding `normal` paragraph just because
+      // both resolved styles happen to already be resolved by the time the
+      // merge runs; the flat path never merges across a style change, so
+      // neither should the decline fallback.
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}, {name: 'blockquote'}],
+          lists: [{name: 'bullet'}],
+        }),
+      )
+      const markdown = ['- para one', '', '  > quoted inside item'].join('\n')
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {list: () => undefined},
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k1',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k2', text: 'para one', marks: []}],
+          markDefs: [],
+          listItem: 'bullet',
+          level: 1,
+        },
+        {
+          _type: 'block',
+          _key: 'k3',
+          style: 'blockquote',
+          children: [
+            {_type: 'span', _key: 'k4', text: 'quoted inside item', marks: []},
+          ],
+          markDefs: [],
+          listItem: 'bullet',
+          level: 1,
+        },
+      ])
+    })
+
+    test('structural list decline keeps a declined blockquote restyle stamped, mirrors the flat path', () => {
+      // A declined `types.blockquote` restyles its content blocks by
+      // spreading into a new object; a `plainParagraphBlocks` gate that
+      // keys off object identity loses the block's provenance across that
+      // clone, exactly like the fence's fallback-to-text block should never
+      // regain it. The enclosing list decline's stampable check must still
+      // recognize the restyled block as a plain paragraph.
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}, {name: 'blockquote'}],
+          lists: [{name: 'bullet'}],
+        }),
+      )
+      const markdown = ['- item text', '', '  > quoted inside item'].join('\n')
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {list: () => undefined, blockquote: () => undefined},
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k1',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k2', text: 'item text', marks: []}],
+          markDefs: [],
+          listItem: 'bullet',
+          level: 1,
+        },
+        {
+          _type: 'block',
+          _key: 'k3',
+          style: 'blockquote',
+          children: [
+            {_type: 'span', _key: 'k4', text: 'quoted inside item', marks: []},
+          ],
+          markDefs: [],
+          listItem: 'bullet',
+          level: 1,
+        },
+      ])
+    })
+
+    test('structural list decline keeps a degraded fence as its own unstamped block, mirrors the flat path', () => {
+      // The paragraph and the fence's fallback-to-text both resolve to the
+      // same `normal` style, so a style-only merge gate would still wrongly
+      // combine them. The flat path never shares `currentBlock` across a
+      // fence (it always flushes around one), and never stamps the fence's
+      // fallback block with `listItem` at all.
+      const schema = compileSchema(
+        defineSchema({
+          styles: [{name: 'normal'}],
+          lists: [{name: 'bullet'}],
+        }),
+      )
+      const markdown = ['- para one', '', '  ```', '  code here', '  ```'].join(
+        '\n',
+      )
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {list: () => undefined},
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k1',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k2', text: 'para one', marks: []}],
+          markDefs: [],
+          listItem: 'bullet',
+          level: 1,
+        },
+        {
+          _type: 'block',
+          _key: 'k3',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k4', text: 'code here', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    test('lossless structural blockquote decline: schema has a `blockquote` style, nothing reported', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'blockquote',
+              fields: [{name: 'content', type: 'array'}],
+            },
+          ],
+          styles: [{name: 'normal'}, {name: 'blockquote'}],
+        }),
+      )
+
+      const declined = markdownToPortableText('> foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {blockquote: () => undefined},
+        onDegradation,
+      })
+
+      const neverRegistered = markdownToPortableText('> foo', {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'blockquote',
+        },
+      ])
+      expect(onDegradation).not.toHaveBeenCalled()
+    })
+
+    test('structural blockquote decline on a style-less schema mirrors the flat path, headings included', () => {
+      const declineDegradation = vi.fn<(report: DegradationReport) => void>()
+      const flatDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'blockquote',
+              fields: [{name: 'content', type: 'array'}],
+            },
+          ],
+          styles: [{name: 'normal'}, {name: 'h1'}],
+        }),
+      )
+      const markdown = ['> # Title', '> body'].join('\n')
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {blockquote: () => undefined},
+        onDegradation: declineDegradation,
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        onDegradation: flatDegradation,
+      })
+
+      // The flat path keeps the heading's own style; only the plain
+      // paragraph picks up `blockquote`.
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'h1',
+          children: [{_type: 'span', _key: 'k1', text: 'Title', marks: []}],
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k3', text: 'body', marks: []}],
+          markDefs: [],
+        },
+      ])
+
+      const expectedDegradations = [
+        {
+          type: 'style-fallback',
+          message:
+            'Blockquote became normal paragraphs: the schema has no `blockquote` style',
+          line: 1,
+        },
+      ]
+      expect(declineDegradation.mock.calls[0]![0]!.degradations).toEqual(
+        expectedDegradations,
+      )
+      expect(flatDegradation.mock.calls[0]![0]!.degradations).toEqual(
+        expectedDegradations,
+      )
+    })
+
+    test('structural blockquote decline on a schema without `h1`: a heading that already fell back to `normal` mirrors the flat path, not restyled to `blockquote`', () => {
+      // The heading's own style resolution already declined to `normal`
+      // before the blockquote fallback runs, so by resolved name alone it's
+      // indistinguishable from a plain paragraph. The flat path never
+      // restyles it (only paragraphs pick up `blockquote`), and neither
+      // should the decline fallback: gated on `plainParagraphBlocks`
+      // provenance, not the block's resolved style name.
+      const schema = compileSchema(
+        defineSchema({styles: [{name: 'normal'}, {name: 'blockquote'}]}),
+      )
+      const markdown = ['> # head', '> body one', '>', '> body two'].join('\n')
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {blockquote: () => undefined},
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k1', text: 'head', marks: []}],
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'blockquote',
+          children: [{_type: 'span', _key: 'k3', text: 'body one', marks: []}],
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          _key: 'k4',
+          style: 'blockquote',
+          children: [{_type: 'span', _key: 'k5', text: 'body two', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    test('structural blockquote decline on a codeless schema: a fence fallen back to text mirrors the flat path, not restyled to `blockquote`', () => {
+      // The fence's fallback-to-text block resolves to `normal`, same as a
+      // plain paragraph would, but the flat path never stamps it with
+      // `blockquote` (only paragraphs pick that up), so neither does the
+      // decline fallback.
+      const schema = compileSchema(
+        defineSchema({styles: [{name: 'normal'}, {name: 'blockquote'}]}),
+      )
+      const markdown = ['> before', '>', '> ```js', '> code()', '> ```'].join(
+        '\n',
+      )
+
+      const declined = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+        types: {blockquote: () => undefined},
+      })
+
+      const neverRegistered = markdownToPortableText(markdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema,
+      })
+
+      expect(omitKeys(declined)).toEqual(omitKeys(neverRegistered))
+      expect(declined).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'blockquote',
+          children: [{_type: 'span', _key: 'k1', text: 'before', marks: []}],
+          markDefs: [],
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'normal',
+          children: [{_type: 'span', _key: 'k3', text: 'code()', marks: []}],
+          markDefs: [],
+        },
+      ])
+    })
+
+    test('annotation dropped: link with an empty href', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo [bar]() baz', {
+          keyGenerator,
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: 'foo bar baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'annotation-dropped',
+          message: 'Removed a link that has no URL, kept its text',
+          line: 1,
+          snippet: 'bar',
+        },
+      ])
+    })
+
+    test('annotation dropped: undeclared `link` annotation', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      expect(
+        markdownToPortableText('foo [bar](https://example.com) baz', {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+          onDegradation,
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [
+            {_type: 'span', _key: 'k1', text: 'foo bar baz', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'annotation-dropped',
+          message:
+            'Removed the link, kept its text: the schema has no `link` annotation',
+          line: 1,
+          snippet: 'bar',
+        },
+      ])
+    })
+
+    test('a consumer throw enforces against lossy output, its message the canonical grouped text', () => {
+      const degradingMarkdown = [
+        '# foo',
+        '',
+        '**bar**',
+        '',
+        '```js',
+        'code',
+        '```',
+      ].join('\n')
+      const throwErrorMessage = [
+        'Markdown could not be converted without loss:',
+        '- line 1: `#` heading became a normal paragraph: the schema has no `h1` style ("foo")',
+        '- line 3: Removed bold formatting, kept the text: the schema has no `strong` decorator ("bar")',
+        '- line 5: `js` code block became plain text: the schema has no `code` block object ("code")',
+      ].join('\n')
+
+      const run = () =>
+        markdownToPortableText(degradingMarkdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema: compileSchema(defineSchema({})),
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        })
+
+      expect(run).toThrow(Error)
+
+      let thrown: unknown
+      try {
+        run()
+      } catch (error) {
+        thrown = error
+      }
+
+      expect(thrown).toBeInstanceOf(Error)
+      expect((thrown as Error).message).toBe(throwErrorMessage)
+    })
+
+    test('a prior call is unaffected by a later call whose consumer throws', () => {
+      const degradingMarkdown = ['# foo', '', '**bar**'].join('\n')
+      const degradingSchema = compileSchema(defineSchema({}))
+
+      const blocksBeforeThrow = markdownToPortableText(degradingMarkdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema: degradingSchema,
+      })
+
+      expect(() =>
+        markdownToPortableText(degradingMarkdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema: degradingSchema,
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrow(Error)
+
+      const blocksAfterThrow = markdownToPortableText(degradingMarkdown, {
+        keyGenerator: createTestKeyGenerator(),
+        schema: degradingSchema,
+      })
+
+      expect(blocksAfterThrow).toEqual(blocksBeforeThrow)
+      expect(blocksBeforeThrow).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+        {
+          _type: 'block',
+          _key: 'k2',
+          children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    test('clean input never invokes the callback, even a throwing one', () => {
+      const keyGenerator = createTestKeyGenerator()
+
+      expect(
+        markdownToPortableText('foo', {
+          keyGenerator,
+          onDegradation: () => {
+            throw new Error('should not run')
+          },
+        }),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          children: [{_type: 'span', _key: 'k1', text: 'foo', marks: []}],
+          markDefs: [],
+          style: 'normal',
+        },
+      ])
+    })
+
+    test('groups repeated same-type declines into one line in the canonical message', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const schema = compileSchema(defineSchema({}))
+      const markdown = [
+        '**a**',
+        '',
+        '**b**',
+        '',
+        '**c**',
+        '',
+        '| x |',
+        '| - |',
+        '| y |',
+      ].join('\n')
+
+      expect(() =>
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema,
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          '- Removed bold formatting, kept the text: the schema has no `strong` decorator (3\u00d7: "a", "b", "c")',
+          '- line 7: Table became plain text blocks, rows and columns lost: the schema has no `table` block object',
+        ].join('\n'),
+      )
+    })
+
+    test('the `degradations` array stays ungrouped, one entry per occurrence, for the same repeated markdown', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const schema = compileSchema(defineSchema({}))
+      const markdown = [
+        '**a**',
+        '',
+        '**b**',
+        '',
+        '**c**',
+        '',
+        '| x |',
+        '| - |',
+        '| y |',
+      ].join('\n')
+
+      markdownToPortableText(markdown, {
+        keyGenerator,
+        schema,
+        onDegradation,
+      })
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'decorator-dropped',
+          message:
+            'Removed bold formatting, kept the text: the schema has no `strong` decorator',
+          line: 1,
+          snippet: 'a',
+        },
+        {
+          type: 'decorator-dropped',
+          message:
+            'Removed bold formatting, kept the text: the schema has no `strong` decorator',
+          line: 3,
+          snippet: 'b',
+        },
+        {
+          type: 'decorator-dropped',
+          message:
+            'Removed bold formatting, kept the text: the schema has no `strong` decorator',
+          line: 5,
+          snippet: 'c',
+        },
+        {
+          type: 'table-flattened',
+          message:
+            'Table became plain text blocks, rows and columns lost: the schema has no `table` block object',
+          line: 7,
+        },
+      ])
+    })
+
+    test('snippet truncation: exactly 40 characters, no ellipsis', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const text = 'x'.repeat(40)
+
+      markdownToPortableText(`**${text}**`, {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      expect(onDegradation.mock.calls[0]![0]!.degradations[0]!.snippet).toBe(
+        text,
+      )
+    })
+
+    test('snippet truncation: 41 characters, cut to 40 with an ellipsis', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const text = 'x'.repeat(41)
+
+      markdownToPortableText(`**${text}**`, {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      expect(onDegradation.mock.calls[0]![0]!.degradations[0]!.snippet).toBe(
+        `${'x'.repeat(40)}...`,
+      )
+    })
+
+    test('snippet truncation: a cut landing mid-surrogate-pair backs off instead of splitting it', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const text = `${'x'.repeat(39)}\u{1F44D}`
+
+      markdownToPortableText(`**${text}**`, {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      const snippet = onDegradation.mock.calls[0]![0]!.degradations[0]!.snippet!
+      expect(snippet.isWellFormed()).toBe(true)
+      expect(snippet).toBe(`${'x'.repeat(39)}...`)
+    })
+
+    test('snippet truncation: quoted content is not escaped, and reads oddly in the message (documented, not fixed)', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      markdownToPortableText('**say "hi" now**', {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      expect(onDegradation.mock.calls[0]![0]!.degradations[0]!.snippet).toBe(
+        'say "hi" now',
+      )
+      expect(onDegradation.mock.calls[0]![0]!.message).toBe(
+        [
+          'Markdown could not be converted without loss:',
+          '- line 1: Removed bold formatting, kept the text: the schema has no `strong` decorator ("say "hi" now")',
+        ].join('\n'),
+      )
+    })
+
+    test('snippet with a hard break: the newline is escaped to literal `\\n`, in both the event and the message', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      markdownToPortableText('**foo  \nbar**', {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      expect(onDegradation.mock.calls[0]![0]!.degradations[0]!.snippet).toBe(
+        'foo\\nbar',
+      )
+      expect(onDegradation.mock.calls[0]![0]!.message).toBe(
+        [
+          'Markdown could not be converted without loss:',
+          '- line 1: Removed bold formatting, kept the text: the schema has no `strong` decorator ("foo\\nbar")',
+        ].join('\n'),
+      )
+    })
+
+    test('empty snippet is omitted, not rendered as `("")`: link decline with no text', () => {
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+
+      markdownToPortableText('foo [](http://example.com) bar', {
+        keyGenerator: createTestKeyGenerator(),
+        schema: compileSchema(defineSchema({})),
+        onDegradation,
+      })
+
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'annotation-dropped',
+          message:
+            'Removed the link, kept its text: the schema has no `link` annotation',
+          line: 1,
+        },
+      ])
+      expect(onDegradation.mock.calls[0]![0]!.message).toBe(
+        [
+          'Markdown could not be converted without loss:',
+          '- line 1: Removed the link, kept its text: the schema has no `link` annotation',
+        ].join('\n'),
+      )
+    })
+
+    test('grouped message: a lines-only suffix always leads with the count, like the snippet and none-of-the-above shapes', () => {
+      // `types.list` always declines, and the schema has no `bullet` list,
+      // so both the nested and the outer list report the same message: the
+      // group has two entries with lines but no snippets.
+      const markdown = ['- outer', '  - inner'].join('\n')
+
+      expect(() =>
+        markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema: compileSchema(
+            defineSchema({
+              blockObjects: [
+                {name: 'list', fields: [{name: 'items', type: 'array'}]},
+              ],
+            }),
+          ),
+          types: {list: () => undefined},
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          '- Bullet list became plain paragraphs: the schema has no `bullet` list (2\u00d7: lines 1, 2)',
+        ].join('\n'),
+      )
+    })
+
+    test('grouped message: a lines-only suffix dedupes a line repeated by several entries, not just sorts it', () => {
+      // All three cells' `fields-dropped` events pin to the same table start
+      // line (inline tokens inside a cell carry no map of their own), so
+      // the group's line list has one line repeated three times: the count
+      // already says how many, the list should say which lines, once each.
+      const markdown = [
+        '| a |',
+        '| - |',
+        '| ![x](a.png) |',
+        '| ![y](b.png) |',
+        '| ![z](c.png) |',
+      ].join('\n')
+
+      expect(() =>
+        markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema: compileSchema(
+            defineSchema({
+              blockObjects: [
+                {name: 'image', fields: [{name: 'src', type: 'string'}]},
+                {
+                  name: 'table',
+                  fields: [
+                    {name: 'headerRows', type: 'number'},
+                    {name: 'rows', type: 'array'},
+                  ],
+                },
+              ],
+            }),
+          ),
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          "- Dropped `alt` from `image`: not in the schema's `image` fields (3\u00d7: lines 1)",
+        ].join('\n'),
+      )
+    })
+
+    test('grouped message: caps a per-group list at 5 entries, tailed with `and N more`', () => {
+      const markdown = [
+        '**a**',
+        '',
+        '**b**',
+        '',
+        '**c**',
+        '',
+        '**d**',
+        '',
+        '**e**',
+        '',
+        '**f**',
+      ].join('\n')
+
+      expect(() =>
+        markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema: compileSchema(defineSchema({})),
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          '- Removed bold formatting, kept the text: the schema has no `strong` decorator (6\u00d7: "a", "b", "c", "d", "e", and 1 more)',
+        ].join('\n'),
+      )
+    })
+
+    test("grouped message: groups sort by their minimum line, not their first-encountered entry's", () => {
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [
+            {
+              name: 'blockquote',
+              fields: [{name: 'content', type: 'array'}],
+            },
+          ],
+        }),
+      )
+      // The outer blockquote (line 1) closes last, so its `style-fallback`
+      // entry (line 1) arrives after the inner one's (line 4): the group's
+      // first-encountered line is 4, but its minimum is 1. The unrelated
+      // `**bar**` on line 3 falls strictly between the two, so sorting by
+      // minimum (not first-encountered) line changes which group leads.
+      const markdown = ['> foo', '>', '> **bar**', '>> baz'].join('\n')
+
+      expect(() =>
+        markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+          schema,
+          types: {blockquote: () => undefined},
+          onDegradation: ({message}) => {
+            throw new Error(message)
+          },
+        }),
+      ).toThrowError(
+        [
+          'Markdown could not be converted without loss:',
+          '- Blockquote became normal paragraphs: the schema has no `blockquote` style (2\u00d7: lines 1, 4)',
+          '- line 3: Removed bold formatting, kept the text: the schema has no `strong` decorator ("bar")',
+        ].join('\n'),
+      )
+    })
+
+    test('object carrier invalid: a `json:object` fence with malformed JSON falls back to a code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = ['```json:object', '{"_type": "product",', '```'].join(
+        '\n',
+      )
+
+      expect(
+        markdownToPortableText(markdown, {keyGenerator, onDegradation}),
+      ).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '{"_type": "product",',
+          language: 'json:object',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'object-carrier-invalid',
+          message:
+            '`json:object` fence fell back to a code block: the payload is not valid JSON',
+          line: 1,
+          snippet: '{"_type": "product",',
+        },
+      ])
+    })
+
+    test('object carrier invalid: a `json:object` fence missing `_type` falls back to a code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = ['```json:object', '{"sku": "abc-123"}', '```'].join(
+        '\n',
+      )
+
+      expect(
+        markdownToPortableText(markdown, {keyGenerator, onDegradation}),
+      ).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '{"sku": "abc-123"}',
+          language: 'json:object',
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'object-carrier-invalid',
+          message:
+            '`json:object` fence fell back to a code block: the payload has no string `_type`',
+          line: 1,
+          snippet: '{"sku": "abc-123"}',
+        },
+      ])
+    })
+
+    test('object carrier invalid: a `json:object`-tagged code span with malformed JSON stays a plain code span', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = 'json:object`{"_type":"stockTicker"`'
+
+      expect(
+        markdownToPortableText(markdown, {keyGenerator, onDegradation}),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'json:object', marks: []},
+            {
+              _type: 'span',
+              _key: 'k2',
+              text: '{"_type":"stockTicker"',
+              marks: ['code'],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'object-carrier-invalid',
+          message:
+            '`json:object`-tagged code span fell back to a plain code span: the payload is not valid JSON',
+          line: 1,
+          snippet: '{"_type":"stockTicker"',
+        },
+      ])
+    })
+
+    test('object carrier invalid: a `json:object`-tagged code span missing `_type` stays a plain code span', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const onDegradation = vi.fn<(report: DegradationReport) => void>()
+      const markdown = 'json:object`{"symbol":"AAPL"}`'
+
+      expect(
+        markdownToPortableText(markdown, {keyGenerator, onDegradation}),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'json:object', marks: []},
+            {
+              _type: 'span',
+              _key: 'k2',
+              text: '{"symbol":"AAPL"}',
+              marks: ['code'],
+            },
+          ],
+        },
+      ])
+
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'object-carrier-invalid',
+          message:
+            '`json:object`-tagged code span fell back to a plain code span: the payload has no string `_type`',
+          line: 1,
+          snippet: '{"symbol":"AAPL"}',
         },
       ])
     })

--- a/packages/markdown/src/to-portable-text/degradation-messages.ts
+++ b/packages/markdown/src/to-portable-text/degradation-messages.ts
@@ -1,0 +1,133 @@
+import type {DegradationType} from './markdown-to-portable-text'
+
+/**
+ * The full catalog of `Degradation['message']` prose, one entry per
+ * `DegradationType`, grouped and ordered to match the union in
+ * `markdown-to-portable-text.ts`. Kept apart from the conversion's
+ * formatting mechanism (`buildDegradationMessage` and friends, in
+ * `markdown-to-portable-text.ts`) so the catalog reads as one list instead
+ * of being scattered across the walk that triggers it.
+ *
+ * `satisfies Record<DegradationType, ...>` makes the catalog exhaustive: a
+ * new `DegradationType` member without a matching entry here is a type
+ * error, caught at compile time instead of surfacing as an `undefined`
+ * message at runtime.
+ *
+ * Style rule for every message here: a declarative statement of what
+ * happened, never a verb that can parse as an imperative. A verb whose past
+ * and imperative forms coincide ("split", "set", "cut", ...) never leads a
+ * message, since the reader can't tell "X was split" from an instruction to
+ * split X. State the effect first, the cause second, naming the schema
+ * declaration that's missing.
+ *
+ * Not exported from the package entry: `message` is unstable by contract
+ * (see `Degradation['message']`'s doc comment), so the catalog producing it
+ * stays internal too.
+ */
+export const degradationMessage = {
+  'decorator-dropped': (
+    decorator: 'code' | 'strong' | 'em' | 'strikeThrough',
+  ): string => {
+    switch (decorator) {
+      case 'code':
+        return 'Removed inline-code formatting, kept the text: the schema has no `code` decorator'
+      case 'strong':
+        return 'Removed bold formatting, kept the text: the schema has no `strong` decorator'
+      case 'em':
+        return 'Removed italic formatting, kept the text: the schema has no `em` decorator'
+      case 'strikeThrough':
+        return 'Removed strikethrough formatting, kept the text: the schema has no `strike-through` decorator'
+    }
+  },
+
+  'annotation-dropped': (cause: 'missing-url' | 'no-annotation'): string =>
+    cause === 'missing-url'
+      ? 'Removed a link that has no URL, kept its text'
+      : 'Removed the link, kept its text: the schema has no `link` annotation',
+
+  'style-fallback': (name: string): string => {
+    if (/^h[1-6]$/.test(name)) {
+      const hashes = '#'.repeat(Number(name.slice(1)))
+      return `\`${hashes}\` heading became a normal paragraph: the schema has no \`${name}\` style`
+    }
+
+    if (name === 'blockquote') {
+      return 'Blockquote became normal paragraphs: the schema has no `blockquote` style'
+    }
+
+    return `Fell back to \`normal\` style: \`${name}\` not in schema`
+  },
+
+  'list-flattened': (kind: 'bullet' | 'number'): string => {
+    const label = kind === 'number' ? 'Numbered' : 'Bullet'
+    return `${label} list became plain paragraphs: the schema has no \`${kind}\` list`
+  },
+
+  'task-checkbox-stripped': (checked: boolean): string => {
+    const checkbox = checked ? '[x]' : '[ ]'
+    return `Removed the \`${checkbox}\` checkbox, kept a plain list item: the schema has no \`task\` list`
+  },
+
+  'table-flattened':
+    'Table became plain text blocks, rows and columns lost: the schema has no `table` block object',
+
+  'code-block-to-text': (language: string | undefined): string =>
+    language
+      ? `\`${language}\` code block became plain text: the schema has no \`code\` block object`
+      : `Code block became plain text: the schema has no \`code\` block object`,
+
+  'horizontal-rule-to-text':
+    'Horizontal rule became the text `---`: the schema has no `horizontal-rule` block object',
+
+  'html-block-to-text':
+    'HTML block became plain text: the schema has no `html` block object',
+
+  'inline-html-dropped':
+    'Removed inline HTML tags, kept nothing: `html.inline` is `skip` (the default)',
+
+  'image-block-to-inline': (cause: 'table-cell' | 'no-block-image'): string =>
+    cause === 'table-cell'
+      ? "The image became inline: a table cell can't hold a block-level `image`"
+      : 'The image became inline: the schema has no block-level `image`',
+
+  'image-inline-to-block':
+    'The image became its own block, splitting the paragraph: the schema has no inline `image`',
+
+  'image-to-text':
+    'Image became its markdown source as plain text: the schema has no `image` object',
+
+  'callout-fallback': (calloutType: string, style: string): string =>
+    `\`[!${calloutType.toUpperCase()}]\` callout became ${style}-styled text: the schema has no \`callout\` block object`,
+
+  'fields-dropped': (names: string, construct: string): string =>
+    `Dropped ${names} from \`${construct}\`: not in the schema's \`${construct}\` fields`,
+
+  'object-carrier-invalid': (
+    kind: 'fence' | 'code-span',
+    payload: string,
+  ): string =>
+    kind === 'fence'
+      ? `\`json:object\` fence fell back to a code block: ${describeObjectCarrierFailure(payload)}`
+      : `\`json:object\`-tagged code span fell back to a plain code span: ${describeObjectCarrierFailure(payload)}`,
+} satisfies Record<DegradationType, string | ((...args: never[]) => string)>
+
+/**
+ * Names why a `json:object` payload failed to parse as an object carrier:
+ * a payload that isn't a JSON object at all reads differently from one
+ * that is but has no usable `_type`.
+ */
+function describeObjectCarrierFailure(payload: string): string {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(payload)
+  } catch {
+    return 'the payload is not valid JSON'
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return 'the payload is not a JSON object'
+  }
+
+  return 'the payload has no string `_type`'
+}

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -35,12 +35,14 @@ import {
 } from '../default-schema'
 import {unescapeImageAndLinkText} from '../escape'
 import {defaultKeyGenerator} from '../key-generator'
+import {degradationMessage} from './degradation-messages'
 import {
   buildAnnotationMatcher,
   buildDecoratorMatcher,
   buildListItemMatcher,
   buildObjectMatcher,
   buildStyleMatcher,
+  readDroppedFields,
   type AnnotationMatcher,
   type DecoratorMatcher,
   type ExtractValue,
@@ -49,9 +51,85 @@ import {
   type StyleMatcher,
 } from './matchers'
 
+/**
+ * The classification of a lossy conversion encountered while converting
+ * markdown to Portable Text: a markdown construct the conversion couldn't
+ * carry through losslessly, whether because the target schema (or the
+ * active matchers) doesn't represent it, or because the surrounding
+ * structure (a table cell, for instance) can't hold the shape markdown
+ * expressed, so the conversion fell back to a lossier representation
+ * instead of failing.
+ *
+ * @public
+ */
+export type DegradationType =
+  | 'decorator-dropped'
+  | 'annotation-dropped'
+  | 'style-fallback'
+  | 'list-flattened'
+  | 'task-checkbox-stripped'
+  | 'table-flattened'
+  | 'code-block-to-text'
+  | 'horizontal-rule-to-text'
+  | 'html-block-to-text'
+  | 'inline-html-dropped'
+  | 'image-block-to-inline'
+  | 'image-inline-to-block'
+  | 'image-to-text'
+  | 'callout-fallback'
+  | 'fields-dropped'
+  | 'object-carrier-invalid'
+
+/**
+ * Reports a single lossy conversion, in encounter order: as the conversion
+ * walks the markdown, that's the order nested constructs close in, not
+ * necessarily top-to-bottom document order. `line` is the 1-based markdown
+ * source line: usually the line of the token that degraded, but for a
+ * token without its own line (an inline construct inside a table cell, for
+ * instance) the enclosing construct's line instead; absent when no token
+ * carries a usable line at all. `snippet` is the offending construct's
+ * text, truncated to 40 characters with an ellipsis, present whenever the
+ * degradation has a specific piece of source text to quote (a dropped
+ * decorator's span, an unsupported image's alt text) and absent when the
+ * construct has nothing to quote (a table with no `table` block object, a
+ * callout whose type isn't in the schema). `message` is human-readable and
+ * may change between releases; match on `type`, not `message`. The set of
+ * `type` values grows in minor releases as new degradation sites report, so
+ * compare against the values you handle rather than switching exhaustively.
+ *
+ * @public
+ */
+export type Degradation = {
+  type: DegradationType
+  message: string
+  line?: number
+  snippet?: string
+}
+
 type Options = {
   schema?: Schema
   keyGenerator?: () => string
+  /**
+   * Called at most once, after the conversion has walked the whole
+   * document, only when at least one construct degraded. Left unset, the
+   * conversion stays silent and returns the lossiest representation it can
+   * build. Passed a function, observe every degradation via
+   * `report.degradations`, in encounter order. Enforce against lossy output by
+   * throwing your own error from inside the callback, using
+   * `report.message` (the canonical grouped text) as its message; the
+   * throw propagates out of `markdownToPortableText`.
+   *
+   * ```ts
+   * markdownToPortableText(markdown, {onDegradation: ({message}) => { throw new Error(message) }})
+   * ```
+   *
+   * `report` is a single object, not positional parameters, so it can gain
+   * fields later without a breaking change.
+   */
+  onDegradation?: (report: {
+    degradations: Array<Degradation>
+    message: string
+  }) => void
   marks?: {
     strong?: DecoratorMatcher
     em?: DecoratorMatcher
@@ -275,6 +353,177 @@ function flattenTable(
 }
 
 /**
+ * Truncates a degradation message's snippet to keep the thrown/reported
+ * message readable. Truncates on character count, not word boundaries: the
+ * snippet is a diagnostic pointer back to the source, not prose. Undefined
+ * for empty input, so a construct with nothing to quote (an empty link's
+ * text, say) omits `snippet` entirely instead of reporting `""`. Backs the
+ * cut off by one unit when it would land on a lead surrogate, so a snippet
+ * ending mid-emoji doesn't produce an unpaired surrogate. A literal newline
+ * surviving into the snippet is escaped to `\n`, since the reported message
+ * is one line per finding.
+ */
+function truncateSnippet(text: string, maxLength = 40): string | undefined {
+  if (text.length === 0) {
+    return undefined
+  }
+
+  if (text.length <= maxLength) {
+    return text.replace(/\n/g, '\\n')
+  }
+
+  let cut = maxLength
+  const codeUnit = text.charCodeAt(cut - 1)
+  if (codeUnit >= 0xd800 && codeUnit <= 0xdbff) {
+    cut -= 1
+  }
+
+  return `${text.slice(0, cut).replace(/\n/g, '\\n')}...`
+}
+
+/**
+ * Concatenates the plain text between an inline open token (`strong_open`,
+ * `em_open`, `s_open`, `link_open`) and its matching close, for use as a
+ * degradation message snippet. Tracks nesting depth so a same-type token
+ * nested inside itself doesn't stop the scan at the wrong close.
+ */
+function collectInlineText(
+  children: ReadonlyArray<{type: string; content: string}>,
+  openIndex: number,
+  openType: string,
+  closeType: string,
+): string {
+  let depth = 1
+  let text = ''
+  for (let i = openIndex + 1; i < children.length; i++) {
+    const child = children[i]
+    if (!child) {
+      continue
+    }
+    if (child.type === openType) {
+      depth++
+    } else if (child.type === closeType) {
+      depth--
+      if (depth === 0) {
+        break
+      }
+    } else if (child.type === 'text') {
+      text += child.content
+    } else if (child.type === 'softbreak') {
+      text += ' '
+    } else if (child.type === 'hardbreak') {
+      text += '\n'
+    }
+  }
+  return text
+}
+
+// A per-group snippet/line list longer than this is truncated with an
+// `and N more` tail: the grouped message is a one-line-per-finding summary,
+// not a full dump of every occurrence (that's what `degradations` is for).
+const MAX_LISTED_PER_GROUP = 5
+
+function capList(values: ReadonlyArray<string>): string {
+  if (values.length <= MAX_LISTED_PER_GROUP) {
+    return values.join(', ')
+  }
+  const shown = values.slice(0, MAX_LISTED_PER_GROUP)
+  const more = values.length - MAX_LISTED_PER_GROUP
+  return `${shown.join(', ')}, and ${more} more`
+}
+
+/**
+ * Builds the canonical grouped message reported alongside a non-empty
+ * `degradations` array: identical (`type`, `message`) pairs collapse into one
+ * line, so a document with the same missing decorator on three spans
+ * doesn't repeat the same sentence three times. Groups sort by their
+ * earliest-lined entry so the message reads top-to-bottom regardless of walk
+ * order: nested constructs (a blockquote inside a blockquote, say) report
+ * the innermost closing first even though it opened last, and that line may
+ * arrive after another entry already in the group. Groups without any lined
+ * entry sort last, in their relative encounter order.
+ */
+function buildDegradationMessage(degradations: Array<Degradation>): string {
+  const groups: Array<{
+    base: string
+    entries: Array<Degradation>
+  }> = []
+  const groupIndexByKey = new Map<string, number>()
+
+  for (const degradation of degradations) {
+    const key = `${degradation.type}\u0000${degradation.message}`
+    let groupIndex = groupIndexByKey.get(key)
+    if (groupIndex === undefined) {
+      groupIndex = groups.length
+      groupIndexByKey.set(key, groupIndex)
+      groups.push({base: degradation.message, entries: []})
+    }
+    groups[groupIndex]!.entries.push(degradation)
+  }
+
+  const minLine = (entries: Array<Degradation>): number | undefined => {
+    const definedLines = entries
+      .map((entry) => entry.line)
+      .filter((line): line is number => line !== undefined)
+    return definedLines.length > 0 ? Math.min(...definedLines) : undefined
+  }
+
+  const sortedGroups = [...groups].sort((a, b) => {
+    const lineA = minLine(a.entries)
+    const lineB = minLine(b.entries)
+    if (lineA === undefined) {
+      return lineB === undefined ? 0 : 1
+    }
+    if (lineB === undefined) {
+      return -1
+    }
+    return lineA - lineB
+  })
+
+  const lines = sortedGroups.map((group) => {
+    if (group.entries.length === 1) {
+      const event = group.entries[0]!
+      const snippetPart =
+        event.snippet === undefined ? '' : ` ("${event.snippet}")`
+      return event.line === undefined
+        ? `- ${event.message}${snippetPart}`
+        : `- line ${event.line}: ${event.message}${snippetPart}`
+    }
+
+    const snippets = group.entries
+      .map((entry) => entry.snippet)
+      .filter((snippet): snippet is string => snippet !== undefined)
+
+    // Read top-to-bottom regardless of encounter order, same reasoning as
+    // the group sort above. Entries without a line are counted but never
+    // printed: joining a maybe-`undefined` would put the literal word
+    // `undefined` in the message. Deduped: several entries in the group can
+    // share one line (a table's cells, all pinned to the table's start
+    // line), and the count already carries how many there were.
+    const linesAscending = [
+      ...new Set(
+        group.entries
+          .map((entry) => entry.line)
+          .filter((line): line is number => line !== undefined)
+          .sort((a, b) => a - b),
+      ),
+    ]
+
+    const count = group.entries.length
+    const suffix =
+      snippets.length === count
+        ? `(${count}\u00d7: ${capList(snippets.map((snippet) => `"${snippet}"`))})`
+        : linesAscending.length > 0
+          ? `(${count}\u00d7: lines ${capList(linesAscending.map(String))})`
+          : `(${count}\u00d7)`
+
+    return `- ${group.base} ${suffix}`
+  })
+
+  return ['Markdown could not be converted without loss:', ...lines].join('\n')
+}
+
+/**
  * Converts a markdown string to an array of Portable Text blocks.
  *
  * @public
@@ -307,6 +556,71 @@ export function markdownToPortableText(
     },
   }
 
+  const degradationEvents: Array<Degradation> = []
+
+  const report = (event: Degradation): void => {
+    degradationEvents.push(event)
+  }
+
+  // A markdown-it token's `map` is `[startLine, endLine)`, 0-based. Degradation
+  // events report the 1-based start line for readability.
+  const lineOf = (
+    candidateToken: {map?: [number, number] | null} | null | undefined,
+  ): number | undefined =>
+    candidateToken?.map ? candidateToken.map[0] + 1 : undefined
+
+  const reportStyleFallback = (
+    name: string,
+    line?: number,
+    snippet?: string,
+  ): void => {
+    if (/^h[1-6]$/.test(name)) {
+      const truncated =
+        snippet === undefined ? undefined : truncateSnippet(snippet)
+      report({
+        type: 'style-fallback',
+        message: degradationMessage['style-fallback'](name),
+        line,
+        snippet: truncated,
+      })
+      return
+    }
+
+    if (name === 'blockquote') {
+      report({
+        type: 'style-fallback',
+        message: degradationMessage['style-fallback'](name),
+        line,
+      })
+      return
+    }
+
+    report({
+      type: 'style-fallback',
+      message: degradationMessage['style-fallback'](name),
+      line,
+    })
+  }
+
+  // Only a default matcher (`buildObjectMatcher`, `buildAnnotationMatcher`)
+  // tags its return value this way; a consumer-supplied matcher's output
+  // passes through untouched, since its own filtering is its own business.
+  const reportFieldsDropped = (
+    object: PortableTextObject | undefined,
+    line: number | undefined,
+  ): void => {
+    const dropped = readDroppedFields(object)
+    if (!dropped) {
+      return
+    }
+    const names = dropped.keys.map((key) => `\`${key}\``).join(', ')
+    report({
+      type: 'fields-dropped',
+      message: degradationMessage['fields-dropped'](names, dropped.construct),
+      line,
+    })
+  }
+
   const md = markdownit({
     html: true,
     linkify: true,
@@ -323,6 +637,9 @@ export function markdownToPortableText(
   // state) so the main walk can apply `listItem: 'task'` and `checked` when
   // processing the corresponding `list_item_open` token.
   const taskCheckedByListItemIndex = new Map<number, boolean>()
+  // The item's text (after the checkbox prefix is stripped below), for the
+  // `task-checkbox-stripped` degradation message's snippet.
+  const taskItemTextByListItemIndex = new Map<number, string>()
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i]
     if (token?.type !== 'list_item_open') {
@@ -359,6 +676,7 @@ export function markdownToPortableText(
     // Strip the prefix from the content and the first child text token so the
     // resulting span doesn't include the checkbox marker.
     inlineToken.content = inlineToken.content.slice(match[0].length)
+    taskItemTextByListItemIndex.set(i, inlineToken.content)
     const firstChild = inlineToken.children?.[0]
     if (firstChild && typeof firstChild.content === 'string') {
       firstChild.content = firstChild.content.slice(match[0].length)
@@ -374,12 +692,35 @@ export function markdownToPortableText(
   let currentMarkDefs: Array<PortableTextObject> = []
   let currentBlockquoteStyle: string | null = null // Track blockquote style when inside blockquote
   let inListItem = false // Track if we're inside a list item
+  // Provenance for `currentBlock`, set by `startBlock`'s caller: whether the
+  // block's style was actually resolved through `currentBlockquoteStyle`
+  // (a paragraph, say) rather than independently landing on the same value
+  // by coincidence (a heading whose own style declined to the same
+  // `normal` fallback). `flushBlock`'s callout gate reads this instead of
+  // comparing styles, since two independent declines can resolve to the
+  // same style name without either one being the other.
+  let currentBlockTookBlockquoteStyle = false
+  // Provenance for `currentBlock`: whether it was created to accumulate
+  // paragraph text (a `paragraph_open`, or inline content starting a block
+  // with no wrapper) as opposed to a dedicated single-purpose block (a
+  // heading, a table cell, a code/HTML/hr fallback-to-text). A structural
+  // list's decline fallback merges adjacent item content back into the flat
+  // path's shape, and the flat path only ever merges accumulated paragraph
+  // blocks: a fallback-to-text block always flushes and starts its own
+  // block explicitly, never sharing `currentBlock` with surrounding text.
+  let currentBlockIsPlainParagraph = false
+  const plainParagraphBlocks = new WeakSet<PortableTextTextBlock>()
 
   // Callout state
   let calloutStartIndex: number | null = null
   let calloutStartTarget: Array<PortableTextBlock | PortableTextObject> | null =
     null
   let calloutType: string | null = null
+  let calloutStartLine: number | undefined
+  // Style names that declined while setting up the callout's content style,
+  // reported once `alert_title` supplies the callout's own first line (the
+  // marker, not the first content line `alert_open`'s map starts at).
+  let calloutPendingStyleFallbacks: Array<string> = []
 
   // Blockquote container state. When `types.blockquote` is defined and the
   // parser enters a `blockquote_open`, a frame is pushed here. Block
@@ -390,6 +731,7 @@ export function markdownToPortableText(
   const blockquoteStack: Array<{
     startTarget: Array<PortableTextBlock | PortableTextObject>
     startIndex: number
+    line: number | undefined
   }> = []
 
   // Table state
@@ -406,6 +748,7 @@ export function markdownToPortableText(
     headerRows: number
     emptyHeaderDropped: boolean
     alignment: Array<'left' | 'center' | 'right' | null>
+    line: number | undefined
   } | null = null
   let currentTableRow: Array<{
     _type: 'cell'
@@ -413,6 +756,16 @@ export function markdownToPortableText(
     value: Array<PortableTextBlock>
   }> | null = null
   let inTableHead = false
+  // Images demoted from block-level to inline while pushed into a table
+  // cell (see the `inline` case). `td_close`/`th_close` may lift a sole
+  // image child back to block-level losslessly; membership here lets that
+  // lift decide whether to report the demotion, and the value carries which
+  // cause to report it with (a schema-declared block image forced inline by
+  // the cell vs. no block image in the schema at all).
+  const demotedTableImages = new WeakMap<
+    PortableTextObject,
+    'table-cell' | 'no-block-image'
+  >()
 
   // List container state. When `types.list` is defined and the parser enters
   // a `bullet_list_open` / `ordered_list_open`, a structural-list frame is
@@ -431,11 +784,37 @@ export function markdownToPortableText(
     kind: 'bullet' | 'number' | 'task'
     items: Array<ListContainerItem>
     currentItem: ListContainerItem | null
+    line: number | undefined
   }
   // A null entry marks a list that is being handled by the flat path (either
   // because `types.list` is undefined, or because a nested list inside a
   // flat-path list should also stay flat). Parallel to `currentListStack`.
   const listContainerStack: Array<ListContainerFrame | null> = []
+
+  // Flat-path `list-flattened` verdicts, parallel to `currentListStack`: a
+  // list whose own kind (`bullet`/`number`) isn't in the schema doesn't
+  // necessarily degrade, since every item might still resolve through a
+  // `task` checkbox override. The verdict is deferred to the first item
+  // that actually needs the fallback (`list_item_open`'s `listType === null`
+  // branch), so a schema with only a `task` list and an all-checkbox list
+  // reports nothing. `null` marks a list whose own kind resolved fine, so no
+  // verdict is pending.
+  const pendingListFlattenedStack: Array<{
+    line: number | undefined
+    kindName: 'bullet' | 'number'
+    reported: boolean
+  } | null> = []
+
+  // Per-item task-checkbox metadata for structural list items (line + text
+  // snippet), keyed by item object identity. Not stored on the item itself:
+  // `frame.items` is handed verbatim to a consumer's `types.list` matcher,
+  // and this bookkeeping is only needed if that matcher declines and the
+  // fallback needs to reproduce the flat path's `task-checkbox-stripped`
+  // report for the item.
+  const taskInfoByListItem = new WeakMap<
+    ListContainerItem,
+    {line: number | undefined; snippet: string | undefined}
+  >()
 
   /**
    * Returns the array that block emissions should land in. If the innermost
@@ -462,7 +841,10 @@ export function markdownToPortableText(
     blockTarget().push(block as PortableTextBlock)
   }
 
-  const startBlock = (style: string) => {
+  const startBlock = (
+    style: string,
+    provenance?: {tookBlockquoteStyle?: boolean; isPlainParagraph?: boolean},
+  ) => {
     flushBlock()
     currentBlock = {
       _type: 'block' as const,
@@ -472,11 +854,32 @@ export function markdownToPortableText(
       markDefs: [],
     }
     currentMarkDefs = []
+    currentBlockTookBlockquoteStyle = provenance?.tookBlockquoteStyle ?? false
+    currentBlockIsPlainParagraph = provenance?.isPlainParagraph ?? false
   }
 
   const flushBlock = () => {
     if (!currentBlock) {
       return
+    }
+
+    // A callout with pending style fallbacks (its own style resolution
+    // declined) only actually degrades once a text block actually commits
+    // needing that resolved style. A heading inside a callout commits with
+    // its own heading style and never touches the callout's content style,
+    // so it doesn't count; a plain paragraph does, since paragraphs adopt
+    // `currentBlockquoteStyle` directly. A callout holding nothing but,
+    // say, a standalone image discards its placeholder block without ever
+    // reaching here (see the `inline` case's standalone-image branch), and
+    // never degraded.
+    if (
+      calloutPendingStyleFallbacks.length > 0 &&
+      currentBlockTookBlockquoteStyle
+    ) {
+      for (const name of calloutPendingStyleFallbacks) {
+        reportStyleFallback(name, calloutStartLine)
+      }
+      calloutPendingStyleFallbacks = []
     }
 
     // Text blocks must have at least one child span
@@ -491,6 +894,10 @@ export function markdownToPortableText(
 
     // Assign accumulated markDefs to the block
     currentBlock.markDefs = currentMarkDefs
+
+    if (currentBlockIsPlainParagraph) {
+      plainParagraphBlocks.add(currentBlock)
+    }
 
     pushBlock(currentBlock)
 
@@ -511,10 +918,13 @@ export function markdownToPortableText(
         })
 
       if (!style) {
-        console.warn('No default style found, using "normal"')
-        startBlock('normal')
+        reportStyleFallback('normal')
+        startBlock('normal', {isPlainParagraph: true})
       } else {
-        startBlock(style)
+        startBlock(style, {
+          tookBlockquoteStyle: currentBlockquoteStyle !== null,
+          isPlainParagraph: true,
+        })
       }
     }
 
@@ -553,10 +963,12 @@ export function markdownToPortableText(
         })
 
       if (!style) {
-        console.warn('No default style found, using "normal"')
+        reportStyleFallback('normal')
         startBlock('normal')
       } else {
-        startBlock(style)
+        startBlock(style, {
+          tookBlockquoteStyle: currentBlockquoteStyle !== null,
+        })
       }
     }
 
@@ -600,9 +1012,16 @@ export function markdownToPortableText(
                 currentBlockquoteStyle ??
                 consolidatedOptions.block.normal({
                   context: {schema: consolidatedOptions.schema},
-                }) ??
-                'normal'
-              startBlock(style)
+                })
+
+              if (!style) {
+                reportStyleFallback('normal', lineOf(token))
+              }
+
+              startBlock(style ?? 'normal', {
+                tookBlockquoteStyle: currentBlockquoteStyle !== null,
+                isPlainParagraph: true,
+              })
             }
             break
           }
@@ -628,12 +1047,15 @@ export function markdownToPortableText(
           })
 
         if (!style) {
-          console.warn('No default style found, using "normal"')
-          startBlock('normal')
+          reportStyleFallback('normal', lineOf(token))
+          startBlock('normal', {isPlainParagraph: true})
           break
         }
 
-        startBlock(style)
+        startBlock(style, {
+          tookBlockquoteStyle: currentBlockquoteStyle !== null,
+          isPlainParagraph: true,
+        })
         break
       }
       case 'paragraph_close':
@@ -666,16 +1088,26 @@ export function markdownToPortableText(
         const headingMatcher =
           headingMatchers[level as keyof typeof headingMatchers]
 
+        const headingStyle = headingMatcher?.({
+          context: {schema: consolidatedOptions.schema},
+        })
+
+        if (!headingStyle) {
+          reportStyleFallback(
+            `h${level}`,
+            lineOf(token),
+            tokens[tokenIndex + 1]?.content,
+          )
+        }
+
         const style =
-          headingMatcher?.({
-            context: {schema: consolidatedOptions.schema},
-          }) ??
+          headingStyle ??
           consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
 
         if (!style) {
-          console.warn('No heading style found, using "normal"')
+          reportStyleFallback('normal', lineOf(token))
           startBlock('normal')
           break
         }
@@ -703,19 +1135,30 @@ export function markdownToPortableText(
           blockquoteStack.push({
             startTarget,
             startIndex: startTarget.length,
+            line: lineOf(token),
           })
           break
         }
 
         // Flat path: set the blockquote style for paragraphs inside the
         // blockquote so they emit text blocks with `style: 'blockquote'`.
+        const blockquoteStyle = consolidatedOptions.block.blockquote({
+          context: {schema: consolidatedOptions.schema},
+        })
+
+        if (!blockquoteStyle) {
+          reportStyleFallback('blockquote', lineOf(token))
+        }
+
         const style =
-          consolidatedOptions.block.blockquote({
-            context: {schema: consolidatedOptions.schema},
-          }) ??
+          blockquoteStyle ??
           consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
+
+        if (!style) {
+          reportStyleFallback('normal', lineOf(token))
+        }
 
         currentBlockquoteStyle = style ?? 'normal'
         break
@@ -750,22 +1193,48 @@ export function markdownToPortableText(
             if (blockquoteObject) {
               pushBlock(blockquoteObject)
             } else {
-              // Matcher returned undefined: fall back to flat-style by
-              // re-emitting each content block with `style: 'blockquote'`.
-              const blockquoteStyle =
-                consolidatedOptions.block.blockquote({
-                  context: {schema: consolidatedOptions.schema},
-                }) ??
+              // Matcher returned undefined: fall back to exactly what the
+              // flat path would have produced (never registering
+              // `types.blockquote` at all), including which events it would
+              // have reported. Only plain paragraphs pick up the blockquote
+              // style there; headings and fallback-to-text blocks (a
+              // degraded code fence, say) keep whatever style they already
+              // resolved to, so restyling is gated on `plainParagraphBlocks`
+              // provenance, not the block's resolved style name.
+              const blockquoteStyle = consolidatedOptions.block.blockquote({
+                context: {schema: consolidatedOptions.schema},
+              })
+
+              if (!blockquoteStyle) {
+                reportStyleFallback('blockquote', frame.line)
+              }
+
+              const resolvedStyle =
+                blockquoteStyle ??
                 consolidatedOptions.block.normal({
                   context: {schema: consolidatedOptions.schema},
-                }) ??
-                'blockquote'
+                })
+
+              if (!resolvedStyle) {
+                reportStyleFallback('normal', frame.line)
+              }
+
+              const fallbackStyle = resolvedStyle ?? 'blockquote'
               for (const block of contentBlocks) {
-                if (block._type === 'block') {
-                  pushBlock({
+                if (
+                  block._type === 'block' &&
+                  plainParagraphBlocks.has(block as PortableTextTextBlock)
+                ) {
+                  const restyledBlock: PortableTextTextBlock = {
                     ...(block as PortableTextTextBlock),
-                    style: blockquoteStyle,
-                  })
+                    style: fallbackStyle,
+                  }
+                  // The spread above makes a new object, so the enclosing
+                  // structural list's stampable gate (keyed on
+                  // `plainParagraphBlocks` object identity) would otherwise
+                  // lose this block's provenance across the restyle.
+                  plainParagraphBlocks.add(restyledBlock)
+                  pushBlock(restyledBlock)
                 } else {
                   pushBlock(block)
                 }
@@ -792,8 +1261,10 @@ export function markdownToPortableText(
             kind: 'bullet',
             items: [],
             currentItem: null,
+            line: lineOf(token),
           })
           currentListStack.push(null)
+          pendingListFlattenedStack.push(null)
           break
         }
 
@@ -805,9 +1276,15 @@ export function markdownToPortableText(
 
         listContainerStack.push(null)
         if (!listItem) {
+          pendingListFlattenedStack.push({
+            line: lineOf(token),
+            kindName: 'bullet',
+            reported: false,
+          })
           currentListStack.push(null)
           break
         }
+        pendingListFlattenedStack.push(null)
         currentListStack.push(listItem)
         break
       }
@@ -819,8 +1296,10 @@ export function markdownToPortableText(
             kind: 'number',
             items: [],
             currentItem: null,
+            line: lineOf(token),
           })
           currentListStack.push(null)
+          pendingListFlattenedStack.push(null)
           break
         }
 
@@ -830,9 +1309,15 @@ export function markdownToPortableText(
 
         listContainerStack.push(null)
         if (!listItem) {
+          pendingListFlattenedStack.push({
+            line: lineOf(token),
+            kindName: 'number',
+            reported: false,
+          })
           currentListStack.push(null)
           break
         }
+        pendingListFlattenedStack.push(null)
         currentListStack.push(listItem)
         break
       }
@@ -840,6 +1325,7 @@ export function markdownToPortableText(
       case 'ordered_list_close': {
         const frame = listContainerStack.pop()
         currentListStack.pop()
+        pendingListFlattenedStack.pop()
 
         // Structural close: materialize the list block-object and push it
         // into the enclosing target (parent list item's content if nested,
@@ -864,47 +1350,107 @@ export function markdownToPortableText(
           if (listObject) {
             pushBlock(listObject)
           } else {
-            // Matcher returned undefined: fall back to the flat path by
-            // re-emitting each item's content. Text blocks get the same
-            // `listItem` + `level` fields the flat path would produce so
-            // adjacent blocks form a list at render time. Non-text-block
-            // content (code blocks, etc.) gets pushed as-is, mirroring
-            // how the flat path handles those when they appear inside a
-            // list item.
-            const flatListItem =
-              (kind === 'task'
-                ? consolidatedOptions.listItem.task?.({
-                    context: {schema: consolidatedOptions.schema},
-                  })
-                : kind === 'number'
-                  ? consolidatedOptions.listItem.number({
-                      context: {schema: consolidatedOptions.schema},
-                    })
-                  : consolidatedOptions.listItem.bullet({
-                      context: {schema: consolidatedOptions.schema},
-                    })) ?? null
+            // Matcher returned undefined: fall back to exactly what the
+            // flat path would have produced for this same content (never
+            // registering `types.list` at all), including which events it
+            // would have reported. A decline whose mirrored flat form is
+            // lossless (the schema has every list kind this list needs)
+            // reports nothing: going structural and being declined isn't
+            // itself a degradation, only losing information is.
+            const kindListItem =
+              (frame.kind === 'number'
+                ? consolidatedOptions.listItem.number
+                : consolidatedOptions.listItem.bullet)({
+                context: {schema: consolidatedOptions.schema},
+              }) ?? null
+            const taskListItemType =
+              consolidatedOptions.listItem.task?.({
+                context: {schema: consolidatedOptions.schema},
+              }) ?? null
+            const kindName = frame.kind === 'number' ? 'number' : 'bullet'
+
             // The just-popped list was nested at depth = remaining stack
             // length + 1 (since we already popped).
             const level = listContainerStack.length + 1
+            let flattenedReported = false
+
             for (const item of frame.items) {
-              for (const block of item.content) {
-                if (
-                  block._type === 'block' &&
-                  flatListItem !== null &&
-                  !('listItem' in block)
-                ) {
-                  const flatBlock = {
-                    ...(block as PortableTextTextBlock),
-                    listItem: flatListItem,
-                    level,
-                    ...(item.checked === undefined
-                      ? {}
-                      : {checked: item.checked}),
-                  }
-                  pushBlock(flatBlock)
-                } else {
-                  pushBlock(block)
+              let itemListType: string | null = kindListItem
+              let itemChecked: boolean | undefined
+
+              if (item.checked !== undefined) {
+                if (taskListItemType) {
+                  itemListType = taskListItemType
+                  itemChecked = item.checked
+                } else if (kindListItem !== null) {
+                  const info = taskInfoByListItem.get(item)
+                  report({
+                    type: 'task-checkbox-stripped',
+                    message: degradationMessage['task-checkbox-stripped'](
+                      item.checked,
+                    ),
+                    line: info?.line,
+                    snippet: info?.snippet,
+                  })
                 }
+              }
+
+              if (itemListType === null && !flattenedReported) {
+                report({
+                  type: 'list-flattened',
+                  message: degradationMessage['list-flattened'](kindName),
+                  line: frame.line,
+                })
+                flattenedReported = true
+              }
+
+              // Adjacent plain-paragraph blocks within one item merge into
+              // a single block, mirroring the flat path: consecutive
+              // `paragraph_open`/`paragraph_close` pairs inside a flat list
+              // item share one `currentBlock`, since only non-paragraph
+              // content (headings, code blocks, ...) flushes it. Resets per
+              // item: `list_item_close` always flushes in the flat path, so
+              // a merge never crosses an item boundary. Gated on
+              // `plainParagraphBlocks` (provenance, not shape): a
+              // fallback-to-text block (a degraded code fence, say) never
+              // shares `currentBlock` with surrounding text in the flat
+              // path either, even when its style happens to match, and the
+              // flat path never stamps it with `listItem` at all.
+              let mergeTarget: PortableTextTextBlock | null = null
+
+              for (const block of item.content) {
+                const isStampable =
+                  itemListType !== null &&
+                  block._type === 'block' &&
+                  !('listItem' in block) &&
+                  !/^h[1-6]$/.test(
+                    (block as PortableTextTextBlock).style ?? '',
+                  ) &&
+                  plainParagraphBlocks.has(block as PortableTextTextBlock)
+
+                if (!isStampable) {
+                  mergeTarget = null
+                  pushBlock(block)
+                  continue
+                }
+
+                const textBlock = block as PortableTextTextBlock
+                if (mergeTarget && mergeTarget.style === textBlock.style) {
+                  mergeTarget.children.push(...textBlock.children)
+                  mergeTarget.markDefs = [
+                    ...(mergeTarget.markDefs ?? []),
+                    ...(textBlock.markDefs ?? []),
+                  ]
+                  continue
+                }
+
+                mergeTarget = {
+                  ...textBlock,
+                  listItem: itemListType as string,
+                  level,
+                  ...(itemChecked === undefined ? {} : {checked: itemChecked}),
+                }
+                pushBlock(mergeTarget)
               }
             }
           }
@@ -930,6 +1476,14 @@ export function markdownToPortableText(
             _key: consolidatedOptions.keyGenerator(),
             ...(taskChecked === undefined ? {} : {checked: taskChecked}),
             content: [],
+          }
+          if (taskChecked !== undefined) {
+            taskInfoByListItem.set(frame.currentItem, {
+              line: lineOf(token),
+              snippet: truncateSnippet(
+                taskItemTextByListItemIndex.get(tokenIndex) ?? '',
+              ),
+            })
           }
           inListItem = true
           break
@@ -963,6 +1517,18 @@ export function markdownToPortableText(
         // If listType is null, it means there's no list definition in the schema
         // Just create a normal block without list properties
         if (listType === null) {
+          const pendingFlattened = pendingListFlattenedStack.at(-1)
+          if (pendingFlattened && !pendingFlattened.reported) {
+            report({
+              type: 'list-flattened',
+              message: degradationMessage['list-flattened'](
+                pendingFlattened.kindName,
+              ),
+              line: pendingFlattened.line,
+            })
+            pendingFlattened.reported = true
+          }
+
           // Use blockquote style if inside a blockquote, otherwise use normal style
           const style =
             currentBlockquoteStyle ??
@@ -971,13 +1537,26 @@ export function markdownToPortableText(
             })
 
           if (!style) {
-            console.warn('No default style found, using "normal"')
+            reportStyleFallback('normal', lineOf(token))
             startBlock('normal')
           } else {
-            startBlock(style)
+            startBlock(style, {
+              tookBlockquoteStyle: currentBlockquoteStyle !== null,
+            })
           }
           inListItem = true
           break
+        }
+
+        if (taskChecked !== undefined && checked === undefined) {
+          const itemText = taskItemTextByListItemIndex.get(tokenIndex) ?? ''
+          const snippet = truncateSnippet(itemText)
+          report({
+            type: 'task-checkbox-stripped',
+            message: degradationMessage['task-checkbox-stripped'](taskChecked),
+            line: lineOf(token),
+            snippet,
+          })
         }
 
         ensureListBlock(listType, checked)
@@ -1018,6 +1597,16 @@ export function markdownToPortableText(
             pushBlock(objectValue as PortableTextObject)
             break
           }
+
+          report({
+            type: 'object-carrier-invalid',
+            message: degradationMessage['object-carrier-invalid'](
+              'fence',
+              code,
+            ),
+            line: lineOf(token),
+            snippet: truncateSnippet(code),
+          })
         }
 
         const codeObject = consolidatedOptions.types.code({
@@ -1030,13 +1619,21 @@ export function markdownToPortableText(
         })
 
         if (!codeObject) {
+          const snippet = truncateSnippet(code.split('\n')[0] ?? '')
+          report({
+            type: 'code-block-to-text',
+            message: degradationMessage['code-block-to-text'](language),
+            line: lineOf(token),
+            snippet,
+          })
+
           // Code block not in schema, fall back to text block
           const style = consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
 
           if (!style) {
-            console.warn('No default style found, using "normal"')
+            reportStyleFallback('normal', lineOf(token))
             startBlock('normal')
           } else {
             startBlock(style)
@@ -1047,6 +1644,7 @@ export function markdownToPortableText(
           break
         }
 
+        reportFieldsDropped(codeObject, lineOf(token))
         pushBlock(codeObject)
 
         break
@@ -1066,13 +1664,19 @@ export function markdownToPortableText(
         })
 
         if (!hrObject) {
+          report({
+            type: 'horizontal-rule-to-text',
+            message: degradationMessage['horizontal-rule-to-text'],
+            line: lineOf(token),
+          })
+
           // If there's no break definition in the schema, parse as text
           const style = consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
 
           if (!style) {
-            console.warn('No default style found, using "normal"')
+            reportStyleFallback('normal', lineOf(token))
             startBlock('normal')
           } else {
             startBlock(style)
@@ -1108,13 +1712,21 @@ export function markdownToPortableText(
         })
 
         if (!htmlObject) {
+          const snippet = truncateSnippet(htmlContent)
+          report({
+            type: 'html-block-to-text',
+            message: degradationMessage['html-block-to-text'],
+            line: lineOf(token),
+            snippet,
+          })
+
           // If there's no HTML block definition in the schema, parse as text
           const style = consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
 
           if (!style) {
-            console.warn('No default style found, using "normal"')
+            reportStyleFallback('normal', lineOf(token))
             startBlock('normal')
           } else {
             startBlock(style)
@@ -1125,6 +1737,7 @@ export function markdownToPortableText(
           break
         }
 
+        reportFieldsDropped(htmlObject, lineOf(token))
         pushBlock(htmlObject)
 
         break
@@ -1146,13 +1759,21 @@ export function markdownToPortableText(
         })
 
         if (!codeObject) {
+          const snippet = truncateSnippet(code.split('\n')[0] ?? '')
+          report({
+            type: 'code-block-to-text',
+            message: degradationMessage['code-block-to-text'](undefined),
+            line: lineOf(token),
+            snippet,
+          })
+
           // Code block not in schema, fall back to text block
           const style = consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
 
           if (!style) {
-            console.warn('No default style found, using "normal"')
+            reportStyleFallback('normal', lineOf(token))
             startBlock('normal')
           } else {
             startBlock(style)
@@ -1161,6 +1782,7 @@ export function markdownToPortableText(
           addSpan(code)
           flushBlock()
         } else {
+          reportFieldsDropped(codeObject, lineOf(token))
           pushBlock(codeObject)
         }
 
@@ -1175,6 +1797,7 @@ export function markdownToPortableText(
           headerRows: 0,
           emptyHeaderDropped: false,
           alignment: [],
+          line: lineOf(token),
         }
         break
 
@@ -1205,8 +1828,14 @@ export function markdownToPortableText(
           })
 
           if (tableObject) {
+            reportFieldsDropped(tableObject, currentTable.line)
             pushBlock(tableObject)
           } else {
+            report({
+              type: 'table-flattened',
+              message: degradationMessage['table-flattened'],
+              line: currentTable.line,
+            })
             // If table object couldn't be created, flatten the table
             flattenTable(
               currentTable,
@@ -1214,6 +1843,11 @@ export function markdownToPortableText(
             )
           }
         } else {
+          report({
+            type: 'table-flattened',
+            message: degradationMessage['table-flattened'],
+            line: currentTable.line,
+          })
           // If there's no table definition in the schema, flatten the table
           flattenTable(currentTable, blockTarget() as Array<PortableTextBlock>)
         }
@@ -1282,7 +1916,7 @@ export function markdownToPortableText(
         })
 
         if (!style) {
-          console.warn('No default style found, using "normal"')
+          reportStyleFallback('normal', currentTable?.line)
           startBlock('normal')
         } else {
           startBlock(style)
@@ -1329,9 +1963,34 @@ export function markdownToPortableText(
           })
         }
 
+        // Images pushed as inline children during this cell (see the
+        // `inline` case below) were demoted from block-level at push time,
+        // before it was known whether the sole-image lift below would
+        // recover them losslessly. Collect them so the lift's verdict can
+        // decide whether the demotion actually degraded anything.
+        const demotedInlineImages: Array<PortableTextObject> = []
+        for (const block of cellBlocks) {
+          if (
+            block._type === 'block' &&
+            'children' in block &&
+            Array.isArray(block.children)
+          ) {
+            for (const child of block.children) {
+              if (
+                typeof child === 'object' &&
+                child !== null &&
+                demotedTableImages.has(child as PortableTextObject)
+              ) {
+                demotedInlineImages.push(child as PortableTextObject)
+              }
+            }
+          }
+        }
+
         // Check if the cell contains a single block with a single image child
         // If so, extract the image as a block-level image
         const firstBlock = cellBlocks[0]
+        let liftedImage: PortableTextObject | undefined
         if (
           cellBlocks.length === 1 &&
           firstBlock &&
@@ -1351,6 +2010,24 @@ export function markdownToPortableText(
           ) {
             // Replace the block with just the image
             cellBlocks[0] = onlyChild as PortableTextBlock
+            liftedImage = onlyChild as PortableTextObject
+          }
+        }
+
+        // A demoted image the lift didn't recover is stuck as an inline
+        // child of the cell's text block: report it now that the verdict is
+        // known, instead of at demotion time.
+        for (const demotedImage of demotedInlineImages) {
+          if (demotedImage !== liftedImage) {
+            const {alt, src} = demotedImage as {alt?: string; src?: string}
+            report({
+              type: 'image-block-to-inline',
+              message: degradationMessage['image-block-to-inline'](
+                demotedTableImages.get(demotedImage) ?? 'table-cell',
+              ),
+              line: currentTable?.line,
+              snippet: truncateSnippet(alt || src || ''),
+            })
           }
         }
 
@@ -1368,6 +2045,11 @@ export function markdownToPortableText(
       case 'inline': {
         // Check if we're in a table cell
         const inTableCell = currentTableRow !== null
+
+        // `inline` tokens inside table cells carry no `map` of their own;
+        // fall back to the enclosing table's line.
+        const inlineLine = (): number | undefined =>
+          lineOf(token) ?? currentTable?.line
 
         // Check if this is a standalone image (paragraph with only an image)
         if (
@@ -1396,7 +2078,13 @@ export function markdownToPortableText(
           })
 
           if (blockImageObject) {
+            reportFieldsDropped(blockImageObject, inlineLine())
             if (inTableCell) {
+              demotedTableImages.set(
+                blockImageObject as PortableTextObject,
+                'table-cell',
+              )
+
               // In table cells, we can't push to portableText directly
               // The block image will be handled in th_close/td_close extraction logic
               // For now, add it as a child of the current block
@@ -1435,17 +2123,40 @@ export function markdownToPortableText(
           })
 
           if (inlineImageObject) {
+            reportFieldsDropped(inlineImageObject, inlineLine())
+            if (inTableCell) {
+              // Defer to the `td_close` sole-image lift: a standalone image
+              // that's the cell's only content round-trips back to
+              // block-level losslessly, and reporting here would be a false
+              // positive for that case.
+              demotedTableImages.set(
+                inlineImageObject as PortableTextObject,
+                'no-block-image',
+              )
+            } else {
+              report({
+                type: 'image-block-to-inline',
+                message:
+                  degradationMessage['image-block-to-inline']('no-block-image'),
+                line: inlineLine(),
+                snippet: truncateSnippet(alt || src),
+              })
+            }
             // Ensure we have a block to add the inline image to
             if (!currentBlock) {
               if (inListItem) {
                 // Structural list: start a plain text block; the image
                 // lands in the current item's content via flushBlock.
                 if (listContainerStack.at(-1)) {
-                  const style =
-                    consolidatedOptions.block.normal({
-                      context: {schema: consolidatedOptions.schema},
-                    }) ?? 'normal'
-                  startBlock(style)
+                  const style = consolidatedOptions.block.normal({
+                    context: {schema: consolidatedOptions.schema},
+                  })
+
+                  if (!style) {
+                    reportStyleFallback('normal', inlineLine())
+                  }
+
+                  startBlock(style ?? 'normal')
                 } else {
                   const listType = currentListStack.at(-1)
 
@@ -1473,6 +2184,13 @@ export function markdownToPortableText(
           }
 
           // Neither block nor inline image supported, fall back to text
+          const standaloneImageSnippet = truncateSnippet(alt || src)
+          report({
+            type: 'image-to-text',
+            message: degradationMessage['image-to-text'],
+            line: inlineLine(),
+            snippet: standaloneImageSnippet,
+          })
           addSpan(`![${alt}](${src})`)
           break
         }
@@ -1485,7 +2203,6 @@ export function markdownToPortableText(
           childIndex++
         ) {
           const childToken = inlineChildren[childIndex]
-
           if (!childToken) {
             continue
           }
@@ -1519,6 +2236,16 @@ export function markdownToPortableText(
                   childIndex++
                   break
                 }
+
+                report({
+                  type: 'object-carrier-invalid',
+                  message: degradationMessage['object-carrier-invalid'](
+                    'code-span',
+                    nextToken.content,
+                  ),
+                  line: inlineLine(),
+                  snippet: truncateSnippet(nextToken.content),
+                })
               }
 
               addSpan(childToken.content)
@@ -1536,6 +2263,13 @@ export function markdownToPortableText(
               })
 
               if (!decorator) {
+                const codeSnippet = truncateSnippet(childToken.content)
+                report({
+                  type: 'decorator-dropped',
+                  message: degradationMessage['decorator-dropped']('code'),
+                  line: inlineLine(),
+                  snippet: codeSnippet,
+                })
                 // No code decorator defined, just add the content without marks
                 addSpan(childToken.content)
                 break
@@ -1559,6 +2293,20 @@ export function markdownToPortableText(
               })
 
               if (!decorator) {
+                const strongSnippet = truncateSnippet(
+                  collectInlineText(
+                    inlineChildren,
+                    childIndex,
+                    'strong_open',
+                    'strong_close',
+                  ),
+                )
+                report({
+                  type: 'decorator-dropped',
+                  message: degradationMessage['decorator-dropped']('strong'),
+                  line: inlineLine(),
+                  snippet: strongSnippet,
+                })
                 break
               }
 
@@ -1588,6 +2336,20 @@ export function markdownToPortableText(
               })
 
               if (!decorator) {
+                const emSnippet = truncateSnippet(
+                  collectInlineText(
+                    inlineChildren,
+                    childIndex,
+                    'em_open',
+                    'em_close',
+                  ),
+                )
+                report({
+                  type: 'decorator-dropped',
+                  message: degradationMessage['decorator-dropped']('em'),
+                  line: inlineLine(),
+                  snippet: emSnippet,
+                })
                 break
               }
 
@@ -1618,6 +2380,21 @@ export function markdownToPortableText(
               })
 
               if (!decorator) {
+                const strikeSnippet = truncateSnippet(
+                  collectInlineText(
+                    inlineChildren,
+                    childIndex,
+                    's_open',
+                    's_close',
+                  ),
+                )
+                report({
+                  type: 'decorator-dropped',
+                  message:
+                    degradationMessage['decorator-dropped']('strikeThrough'),
+                  line: inlineLine(),
+                  snippet: strikeSnippet,
+                })
                 break
               }
 
@@ -1648,6 +2425,21 @@ export function markdownToPortableText(
                 ?.at(1)
 
               if (!href) {
+                const missingHrefSnippet = truncateSnippet(
+                  collectInlineText(
+                    inlineChildren,
+                    childIndex,
+                    'link_open',
+                    'link_close',
+                  ),
+                )
+                report({
+                  type: 'annotation-dropped',
+                  message:
+                    degradationMessage['annotation-dropped']('missing-url'),
+                  line: inlineLine(),
+                  snippet: missingHrefSnippet,
+                })
                 break
               }
 
@@ -1664,9 +2456,25 @@ export function markdownToPortableText(
               })
 
               if (!linkObject) {
+                const linkSnippet = truncateSnippet(
+                  collectInlineText(
+                    inlineChildren,
+                    childIndex,
+                    'link_open',
+                    'link_close',
+                  ),
+                )
+                report({
+                  type: 'annotation-dropped',
+                  message:
+                    degradationMessage['annotation-dropped']('no-annotation'),
+                  line: inlineLine(),
+                  snippet: linkSnippet,
+                })
                 break
               }
 
+              reportFieldsDropped(linkObject, inlineLine())
               currentMarkDefs.push(linkObject)
               markDefRefs.push(linkObject._key)
               break
@@ -1705,6 +2513,7 @@ export function markdownToPortableText(
               })
 
               if (inlineImageObject) {
+                reportFieldsDropped(inlineImageObject, inlineLine())
                 // Inline image is supported - add it to current block
                 if (!currentBlock) {
                   const style = consolidatedOptions.block.normal({
@@ -1712,7 +2521,7 @@ export function markdownToPortableText(
                   })
 
                   if (!style) {
-                    console.warn('No default style found, using "normal"')
+                    reportStyleFallback('normal', inlineLine())
                     startBlock('normal')
                   } else {
                     startBlock(style)
@@ -1743,6 +2552,13 @@ export function markdownToPortableText(
 
               if (!blockImageObject) {
                 // Neither inline nor block image supported
+                const inlineImageSnippet = truncateSnippet(alt || src)
+                report({
+                  type: 'image-to-text',
+                  message: degradationMessage['image-to-text'],
+                  line: inlineLine(),
+                  snippet: inlineImageSnippet,
+                })
                 addSpan(`![${alt}](${src})`)
                 break
               }
@@ -1750,6 +2566,12 @@ export function markdownToPortableText(
               // Block image supported - flush current block and add as block-level
               // Skip if we're in a table cell (images in cells are handled differently)
               if (inTableCell) {
+                reportFieldsDropped(blockImageObject, inlineLine())
+                demotedTableImages.set(
+                  blockImageObject as PortableTextObject,
+                  'table-cell',
+                )
+
                 // In table cells, add the image to current block (will be extracted later)
                 if (currentBlock && 'children' in currentBlock) {
                   ;(currentBlock as PortableTextTextBlock).children.push(
@@ -1760,6 +2582,13 @@ export function markdownToPortableText(
               }
 
               // Not in table - flush current block, add image as block, start new block
+              reportFieldsDropped(blockImageObject, inlineLine())
+              report({
+                type: 'image-inline-to-block',
+                message: degradationMessage['image-inline-to-block'],
+                line: inlineLine(),
+                snippet: truncateSnippet(alt || src),
+              })
               flushBlock()
               pushBlock(blockImageObject)
 
@@ -1778,8 +2607,15 @@ export function markdownToPortableText(
               // Handle inline HTML based on configuration
               if (consolidatedOptions.html.inline === 'text') {
                 addSpan(childToken.content)
+              } else if (childToken.content) {
+                const htmlInlineSnippet = truncateSnippet(childToken.content)
+                report({
+                  type: 'inline-html-dropped',
+                  message: degradationMessage['inline-html-dropped'],
+                  line: inlineLine(),
+                  snippet: htmlInlineSnippet,
+                })
               }
-              // 'skip' - do nothing, ignore the HTML
               break
             }
             default:
@@ -1796,29 +2632,49 @@ export function markdownToPortableText(
         calloutStartTarget = blockTarget()
         calloutStartIndex = calloutStartTarget.length
         calloutType = token.markup
+        calloutStartLine = lineOf(token)
 
         // Set blockquote style so content blocks inside the callout
         // get blockquote styling (used in fallback when callout type
         // is not in the schema)
+        const blockquoteStyle = consolidatedOptions.block.blockquote({
+          context: {schema: consolidatedOptions.schema},
+        })
+
+        calloutPendingStyleFallbacks = []
+        if (!blockquoteStyle) {
+          calloutPendingStyleFallbacks.push('blockquote')
+        }
+
         const style =
-          consolidatedOptions.block.blockquote({
-            context: {schema: consolidatedOptions.schema},
-          }) ??
+          blockquoteStyle ??
           consolidatedOptions.block.normal({
             context: {schema: consolidatedOptions.schema},
           })
+
+        if (!style) {
+          calloutPendingStyleFallbacks.push('normal')
+        }
 
         currentBlockquoteStyle = style ?? 'normal'
         break
       }
 
       case 'alert_title': {
-        // Type is already captured via alert_open's markup
+        // `alert_open`'s own map starts at the first content line; the
+        // marker line (`> [!NOTE]`) is `alert_title`'s. Any pending style
+        // fallbacks flush lazily, from `flushBlock`, once a text block
+        // actually commits needing the style.
+        calloutStartLine = lineOf(token)
         break
       }
 
       case 'alert_close': {
         flushBlock()
+
+        // Nothing ever needed the pending style: no text block materialized
+        // inside the callout, so nothing degraded.
+        calloutPendingStyleFallbacks = []
 
         if (
           calloutStartIndex !== null &&
@@ -1839,8 +2695,17 @@ export function markdownToPortableText(
           })
 
           if (calloutObject) {
+            reportFieldsDropped(calloutObject, calloutStartLine)
             pushBlock(calloutObject)
           } else {
+            report({
+              type: 'callout-fallback',
+              message: degradationMessage['callout-fallback'](
+                calloutType,
+                currentBlockquoteStyle ?? 'normal',
+              ),
+              line: calloutStartLine,
+            })
             for (const block of contentBlocks) {
               pushBlock(block)
             }
@@ -1850,6 +2715,7 @@ export function markdownToPortableText(
         calloutStartIndex = null
         calloutStartTarget = null
         calloutType = null
+        calloutStartLine = undefined
         currentBlockquoteStyle = null
         break
       }
@@ -1860,6 +2726,13 @@ export function markdownToPortableText(
   }
 
   flushBlock()
+
+  if (degradationEvents.length > 0) {
+    options?.onDegradation?.({
+      degradations: degradationEvents,
+      message: buildDegradationMessage(degradationEvents),
+    })
+  }
 
   return portableText
 }

--- a/packages/markdown/src/to-portable-text/matchers.ts
+++ b/packages/markdown/src/to-portable-text/matchers.ts
@@ -5,6 +5,73 @@ import type {
 } from '@portabletext/schema'
 
 /**
+ * Fields a default object/annotation matcher (`buildObjectMatcher`,
+ * `buildAnnotationMatcher`) silently dropped while filtering a converted
+ * value down to the schema's declared fields: the keys the conversion
+ * supplied that the schema's field list doesn't declare, so they never made
+ * it into the built object. Tagged onto the matcher's return value; read it
+ * back with `readDroppedFields`. A consumer-supplied matcher's return value
+ * never carries this: its own filtering, if any, is not this module's
+ * business.
+ */
+export type DroppedFields = {
+  construct: string
+  keys: Array<string>
+}
+
+const droppedFieldsTag = Symbol('droppedFields')
+
+export function readDroppedFields(
+  object: PortableTextObject | undefined,
+): DroppedFields | undefined {
+  if (!object) {
+    return undefined
+  }
+  return (object as unknown as Record<symbol, unknown>)[droppedFieldsTag] as
+    | DroppedFields
+    | undefined
+}
+
+function buildFilteredObject(
+  schemaDefinition: {name: string; fields: ReadonlyArray<{name: string}>},
+  value: Record<string, unknown>,
+  keyGenerator: () => string,
+): PortableTextObject {
+  const filteredValue = schemaDefinition.fields.reduce<Record<string, unknown>>(
+    (filteredValue, field) => {
+      const fieldValue = value[field.name]
+
+      if (fieldValue !== undefined) {
+        filteredValue[field.name] = fieldValue
+      }
+
+      return filteredValue
+    },
+    {},
+  )
+
+  const object = {
+    _key: keyGenerator(),
+    _type: schemaDefinition.name,
+    ...filteredValue,
+  }
+
+  const suppliedKeys = Object.entries(value)
+    .filter(([, fieldValue]) => fieldValue !== undefined)
+    .map(([key]) => key)
+  const droppedKeys = suppliedKeys.filter((key) => !(key in filteredValue))
+
+  if (droppedKeys.length > 0) {
+    Object.defineProperty(object, droppedFieldsTag, {
+      value: {construct: schemaDefinition.name, keys: droppedKeys},
+      enumerable: false,
+    })
+  }
+
+  return object
+}
+
+/**
  * Matcher function for mapping markdown elements to Portable Text block styles.
  *
  * @public
@@ -112,23 +179,7 @@ export function buildAnnotationMatcher<TDefinition extends {name: string}>(
       return undefined
     }
 
-    const filteredValue = schemaDefinition.fields.reduce<
-      Record<string, unknown>
-    >((filteredValue, field) => {
-      const fieldValue = value[field.name as keyof typeof value]
-
-      if (fieldValue !== undefined) {
-        filteredValue[field.name] = fieldValue
-      }
-
-      return filteredValue
-    }, {})
-
-    return {
-      _key: context.keyGenerator(),
-      _type: schemaDefinition.name,
-      ...filteredValue,
-    }
+    return buildFilteredObject(schemaDefinition, value, context.keyGenerator)
   }
 }
 
@@ -165,23 +216,7 @@ export function buildObjectMatcher<TDefinition extends {name: string}>(
       return undefined
     }
 
-    const filteredValue = schemaDefinition.fields.reduce<
-      Record<string, unknown>
-    >((filteredValue, field) => {
-      const fieldValue = value[field.name as keyof typeof value]
-
-      if (fieldValue !== undefined) {
-        filteredValue[field.name] = fieldValue
-      }
-
-      return filteredValue
-    }, {})
-
-    return {
-      _key: context.keyGenerator(),
-      _type: schemaDefinition.name,
-      ...filteredValue,
-    }
+    return buildFilteredObject(schemaDefinition, value, context.keyGenerator)
   }
 }
 


### PR DESCRIPTION
Schema-gating in `markdownToPortableText` degrades gracefully by design: an undeclared decorator drops its formatting, a table flattens, an image becomes its markdown source as plain text. Right for rendering pipelines, and invisible. Agent tooling patching rich text through this conversion needs the losses loud, an agent that wrote a table must learn the table didn't survive, and the accidental feedback channel it relied on (schema validation rejecting output converted against the wrong schema) disappears as soon as conversion runs against the correct schema.

One new option: `onDegradation`, a plain callback called at most once, after the walk, only when something degraded. Its report argument holds `degradations`, the encounter-ordered structured list (`{type, message, line?, snippet?}`, `type` a literal union to match on, `message` explicitly unstable, `snippet` the offending construct's text), and `message`, the canonical text written for the retry loop that reads it: each degradation states its effect in content terms, names the missing schema declaration as a constraint, quotes a snippet as the anchor (LLMs match strings far more reliably than they count lines), and identical degradations group into one line, forty undeclared-bold spans read as one rule. Enforcing is ordinary JavaScript rather than a library mode: `onDegradation: ({message}) => { throw new Error(message) }` propagates out of the conversion, pinned by a test. With the option unset, conversion degrades silently, which also removes the legacy `console.warn` on the eleven style-fallback paths: a library shouldn't log, visibility is opt-in.

A callback that never fires is a totality guarantee, so every site in the parser reports, including four the reviews found silent (structural-list paragraph styles, callout content styles, and the double-decline tiers on headings and flat blockquotes), the table-cell image demotion, and the task-checkbox strip at its consumption site so a structural path that preserves `checked` stays silent. Graceful block output is byte-identical to before, verified across default, sparse, and empty schemas, and pinned by the untouched suite.

`Degradation` is the only new export; its `type` field carries the literal union, which grows as new degradation sites report, so consumers compare against the values they handle rather than switching exhaustively. The option lives on the non-exported options type. The API went through four design iterations before this shape; the decision record with the rejected alternatives lives on the ticket.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core markdown-to-PT conversion path and changes observable logging (warn → silent by default); output shape is intended unchanged, but regression risk is moderate given breadth of degradation sites.
> 
> **Overview**
> Adds **`onDegradation`** to `markdownToPortableText`: when markdown can’t be represented in the schema (missing decorators, flattened tables, stripped task checkboxes, invalid `json:object` carriers, dropped object fields, and similar), conversion still returns the same lossy Portable Text as before, but can **report** every loss in one post-walk callback.
> 
> The report includes an encounter-ordered **`degradations`** array (exported **`Degradation`** type with stable **`type`**, optional **`line`** / **`snippet`**) and a grouped, line-sorted **`message`** for humans or agents. Callers can log, match on `type`, or **throw from the callback** to fail the import. Without the option, behavior stays silent—**`console.warn` on style-fallback paths is removed** in favor of opt-in reporting.
> 
> Implementation wires reporting through the markdown-it walk (new message catalog, snippet truncation, grouping rules) and extends default matchers to tag **fields dropped** when filtering to schema fields. Docs, README, changeset, and a large test suite cover edge cases (structural list/blockquote declines mirroring the flat path, table-cell images, callouts).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff24b791512baf8953ac82665876c056bc312f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

