### PR TITLE
feat: round-trip unknown objects through `json:object` fences and code spans

### DIFF
--- a/.changeset/json-object-fences.md
+++ b/.changeset/json-object-fences.md
@@ -1,0 +1,23 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: round-trip unknown objects through `json:object` fences and code spans
+
+Custom objects now survive Markdown conversion in both directions. `portableTextToMarkdown` renders a block-level object as a ` ```json:object ` fence and an inline object as a `json:object`-tagged code span, and `markdownToPortableText` turns both back into the original objects, `_key` included, no schema required. Previously these objects came back as `code` blocks, and inline objects also split the block around them, so converting to Markdown and back destroyed them.
+
+````md
+```json:object
+{"_type": "product", "_key": "k1", "sku": "abc-123"}
+```
+
+AAPL is at json:object`{"_type": "stockTicker", "_key": "k2", "symbol": "AAPL"}` right now.
+````
+
+Both forms parse back to the objects in the payloads, with the surrounding text intact.
+
+What changes in existing output and parsing:
+
+- Markdown output changes for unknown objects: ` ```json ` fences become ` ```json:object `, and inline objects stay inside their line instead of breaking out.
+- The `json:object` language is reserved. A `code` block with exactly that language keeps its code but loses the language when serialized.
+- A ` ```json:object ` fence or tagged code span that doesn't contain a JSON object with a `_type` parses as ordinary code.

--- a/apps/docs/src/content/docs/conversion/markdown-round-tripping.mdx
+++ b/apps/docs/src/content/docs/conversion/markdown-round-tripping.mdx
@@ -141,20 +141,22 @@ portableTextToMarkdown([
 // -> '- foo\n   - bar\n- baz'
 ```
 
-An unknown object type renders as a fenced JSON block. That block is not a stopgap spelling of the original type: on reparse it comes back as a `code` object, not the type that went out. Round-tripping an unrecognized type through Markdown is destructive.
+Unknown object types are the exception: they round-trip. A block-level object renders as a fence with a `json:object` info string holding the value as JSON, and an inline object as a `json:object`-tagged inline code span. The parser turns both back into the objects they came from, whatever the schema declares.
 
 ````ts
 portableTextToMarkdown([{_type: 'widget', _key: 'w1', color: 'blue'}])
-// -> '```json\n{\n  "_type": "widget",\n  "_key": "w1",\n  "color": "blue"\n}\n```'
+// -> '```json:object\n{\n  "_type": "widget",\n  "_key": "w1",\n  "color": "blue"\n}\n```'
 
 markdownToPortableText(/* the fenced block above */)
-// -> [{_type: 'code', language: 'json', code: '{\n  "_type": "widget",\n  "_key": "w1",\n  "color": "blue"\n}'}]
-// (a 'code' object, not the original 'widget' type)
+// -> [{_type: 'widget', _key: 'w1', color: 'blue'}]
+// (the original object, `_key` included)
 ````
 
-### 5. Identity does not round-trip
+A `json:object` fence or tagged span whose body is not a JSON object with a non-empty string `_type` is ordinary code: it never throws, and it degrades like any other code the schema does or does not declare.
 
-Keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
+### 5. Identity does not round-trip for text blocks
+
+Text block and span keys are regenerated on every parse, and adjacent spans with identical marks merge into one. Unknown objects keep their `_key` through the round trip, since it travels inside the JSON payload.
 
 ```ts
 portableTextToMarkdown([
@@ -195,7 +197,11 @@ portableTextToMarkdown([
 
 ## Exceptions
 
-Three named exceptions qualify the fixpoint claim in guarantee 2 above.
+Five named exceptions qualify the fixpoint claim in guarantee 2 above.
+
+**The reserved `json:object` info string.** A `code` object whose `language` is literally `json:object` loses that language on serialization: emitting it would make the code block re-parse as an embedded object whenever its content happens to be typed JSON. The code itself survives.
+
+**Tagged-span adjacency.** Span text ending in `json:object` directly before a code-marked span holding a JSON object with a string `_type` binds into an inline object on reparse. Escapes cannot prevent it: they resolve before the binding runs.
 
 **Linkified substrings.** An explicit-scheme URL or an email address in a span's text is never escaped: the text stays byte-identical, but it gains a `link` mark on the next parse (autolinking is a parser feature, not a round-trip bug).
 

--- a/apps/docs/src/content/docs/rendering/index.mdx
+++ b/apps/docs/src/content/docs/rendering/index.mdx
@@ -17,7 +17,7 @@ But Portable Text isn't just rich text. The same array can contain **any type of
 
 Within text blocks, **marks** add meaning to inline text. **Decorators** (bold, italic, underline) work by default. **Annotations** (links, references, footnotes) carry structured data as mark definitions. A link annotation isn't just an `<a>` tag: it's a data object with href, target, tracking parameters, or whatever fields you define. You customize annotation rendering through the `marks` component map. Text blocks can also contain **inline objects**: structured data embedded in the text flow, like a stock ticker, a product reference, or a custom emoji. Inline objects are rendered through the same `types` component map as custom blocks.
 
-If a serializer encounters a type it doesn't recognize, it falls back to an unknown-type handler instead of throwing; what that fallback renders varies per serializer (the [Markdown serializer](/rendering/markdown/), for example, renders unrecognized types as a fenced JSON block).
+If a serializer encounters a type it doesn't recognize, it falls back to an unknown-type handler instead of throwing; what that fallback renders varies per serializer (the [Markdown serializer](/rendering/markdown/), for example, renders unrecognized types as a `json:object` fence, or a `json:object`-tagged code span inline, that parses back into the same object).
 
 ## Get started
 
@@ -328,7 +328,7 @@ All serializers use the same component map structure (except Astro, which uses s
 | `listItem`  | List items                      | Custom list item rendering              |
 | `hardBreak` | Line breaks within text         | Custom line break handling              |
 
-Unknown types, marks, and styles go through an unknown-type fallback whose default varies per serializer (the React serializer renders a hidden warning, the Markdown serializer a fenced JSON block). You can take over with `unknownType`, `unknownMark`, `unknownBlockStyle`, `unknownList`, and `unknownListItem` components.
+Unknown types, marks, and styles go through an unknown-type fallback whose default varies per serializer (the React serializer renders a hidden warning, the Markdown serializer a `json:object` fence or tagged code span that parses back into the same object). You can take over with `unknownType`, `unknownMark`, `unknownBlockStyle`, `unknownList`, and `unknownListItem` components.
 
 ## Framework guides
 

--- a/apps/docs/src/content/docs/rendering/markdown.mdx
+++ b/apps/docs/src/content/docs/rendering/markdown.mdx
@@ -29,7 +29,7 @@ const markdown = portableTextToMarkdown(blocks)
 
 ## Custom type renderers
 
-`callout`, `code`, `horizontal-rule`, `html`, `image`, and `table` block objects render as Markdown out of the box. `callout`, `code`, `html`, `image`, and `table` fall back to a fenced JSON block when a value doesn't match the shape its renderer expects (a consumer's own differently-shaped `code` type, say); `horizontal-rule` always renders `---`. Register a renderer for other custom types you use, or to override one of the defaults.
+`callout`, `code`, `horizontal-rule`, `html`, `image`, and `table` block objects render as Markdown out of the box. `callout`, `code`, `html`, `image`, and `table` fall back to a `json:object` fence when a value doesn't match the shape its renderer expects (a consumer's own differently-shaped `code` type, say), which [round-trips back into the same object](/conversion/markdown-round-tripping/); `horizontal-rule` always renders `---`. Register a renderer for other custom types you use, or to override one of the defaults.
 
 ```ts
 portableTextToMarkdown(blocks, {

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -86,11 +86,11 @@ Converting Markdown to Portable Text and back isn't a lossless mirror:
 1. Translation preserves semantics, not source spelling: the first MD→PT→MD pass normalizes Markdown to one canonical spelling (autolinks become inline links, indented code becomes fenced code, soft-wrapped lines join into one, and so on).
 2. The normalized Markdown is a fixpoint for plain text and the [Supported features](#supported-features) table: parsing it and serializing again reproduces it byte-for-byte.
 3. MD→PT survival is schema-driven: a construct whose type the schema doesn't declare keeps its content and drops the structure that named it.
-4. PT structures with no Markdown form degrade predictably on PT→MD (extra table header rows flatten into the body, deep or level-skipping lists collapse to relative nesting, unknown types render as a fenced JSON block).
-5. Identity does not round-trip: keys are regenerated on every parse, and adjacent spans with identical marks merge into one.
+4. PT structures with no Markdown form degrade predictably on PT→MD (extra table header rows flatten into the body, deep or level-skipping lists collapse to relative nesting, unknown marks pass their text through unformatted). Unknown object types round-trip instead: block-level as a ` ```json:object ` fence, inline as a `json:object`-tagged code span, both carrying the value as JSON. A fence or span whose body isn't a JSON object with a `_type` is ordinary code.
+5. Identity does not round-trip for text blocks: keys are regenerated on every parse, and adjacent spans with identical marks merge into one. Unknown objects keep their `_key`.
 6. A hard break and a `\n` in a span's text are exclusive counterparts in both directions: a `\n` always renders as hard-break syntax on the way out, and hard-break syntax always becomes `\n` on the way in, never the space a soft wrap joins with.
 
-Three exceptions to the fixpoint claim: an explicit-scheme URL or email keeps its text but gains a `link` mark on reparse, and a fuzzy `www.` form does too unless it carries markdown-significant punctuation; a hard break inside a heading splits into a second block on reparse, since an ATX heading is single-line; and leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint.
+The named exceptions to the fixpoint claim: an explicit-scheme URL or email keeps its text but gains a `link` mark on reparse, and a fuzzy `www.` form does too unless it carries markdown-significant punctuation; a hard break inside a heading splits into a second block on reparse, since an ATX heading is single-line; leading or trailing whitespace that CommonMark's own block parsing trims isn't part of the fixpoint; a `code` object with the reserved language `json:object` loses that language on serialization; and span text ending in `json:object` directly before a code-marked span holding a typed JSON object binds into an inline object on reparse.
 
 See [Markdown round-tripping](https://www.portabletext.org/conversion/markdown-round-tripping/) on the docs site for the full contract and worked examples.
 
@@ -633,7 +633,7 @@ portableTextToMarkdown(blocks, {
 })
 ```
 
-By default, unknown types render as JSON code blocks, and unknown marks/styles pass through their children unchanged.
+By default, unknown types render as `json:object` fences or tagged code spans that round-trip (see [Round-trip behavior](#round-trip-behavior)), and unknown marks/styles pass through their children unchanged.
 
 You can also customize hard break rendering:
 

--- a/packages/markdown/src/from-portable-text/renderers/marks.ts
+++ b/packages/markdown/src/from-portable-text/renderers/marks.ts
@@ -31,7 +31,10 @@ export const DefaultStrongRenderer: PortableTextMarkRenderer = ({children}) =>
  *
  * @public
  */
-export const DefaultCodeRenderer: PortableTextMarkRenderer = ({text}) => {
+export const DefaultCodeRenderer: PortableTextMarkRenderer = ({text}) =>
+  wrapInCodeSpan(text)
+
+export function wrapInCodeSpan(text: string): string {
   const fence = '`'.repeat(longestBacktickRun(text) + 1)
   const touchesBacktick = text.startsWith('`') || text.endsWith('`')
   const wouldBeStripped =

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -8,6 +8,7 @@ import {
 } from '../../escape'
 import {markListItemFirstBlock} from '../list-item-first-block'
 import type {PortableTextTypeRenderer} from '../types'
+import {wrapInCodeSpan} from './marks'
 
 /**
  * @public
@@ -36,6 +37,13 @@ function isCodeShaped(value: unknown): value is {code: string} {
  */
 function normalizeLanguage(language: unknown): string {
   if (typeof language !== 'string' || language.includes('\n')) {
+    return ''
+  }
+  if (language === 'json:object') {
+    // `json:object` is reserved as the object carrier: a code block
+    // emitting it as its info string would re-parse as the embedded
+    // object whenever its content happens to be typed JSON, destroying
+    // the code block. The language degrades to absent instead.
     return ''
   }
   return language
@@ -453,7 +461,11 @@ export const DefaultUnknownTypeRenderer: PortableTextTypeRenderer = ({
   value,
   isInline,
 }) => {
-  const json = `\`\`\`json\n${JSON.stringify(value, null, 2)}\n\`\`\``
-  // For inline unknown types, add newlines to break them out of the text flow
-  return isInline ? `\n${json}\n` : json
+  if (isInline) {
+    // Single-line JSON: code spans turn newlines into spaces on
+    // reparse, so a pretty-printed payload would still reconstruct but
+    // would not survive byte-identically, breaking the fixpoint.
+    return `json:object${wrapInCodeSpan(JSON.stringify(value))}`
+  }
+  return `\`\`\`json:object\n${JSON.stringify(value, null, 2)}\n\`\`\``
 }

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -6458,4 +6458,228 @@ describe(markdownToPortableText.name, () => {
       ])
     })
   })
+  describe('json:object fence', () => {
+    test('reconstructs the object, `_key` included', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '```json:object',
+        '{"_type": "product", "_key": "product-key", "sku": "abc-123"}',
+        '```',
+      ].join('\n')
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'product',
+          _key: 'product-key',
+          sku: 'abc-123',
+        },
+      ])
+    })
+
+    test('reconstructs regardless of the schema', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '```json:object',
+        '{"_type": "product", "sku": "abc-123"}',
+        '```',
+      ].join('\n')
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator,
+          schema: compileSchema(defineSchema({})),
+        }),
+      ).toEqual([
+        {
+          _type: 'product',
+          sku: 'abc-123',
+        },
+      ])
+    })
+
+    test('a payload without a `_key` stays keyless', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '```json:object',
+        '{"_type": "product", "sku": "abc-123"}',
+        '```',
+      ].join('\n')
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'product',
+          sku: 'abc-123',
+        },
+      ])
+    })
+
+    test('malformed JSON degrades to a code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = ['```json:object', '{"_type": "product",', '```'].join(
+        '\n',
+      )
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '{"_type": "product",',
+          language: 'json:object',
+        },
+      ])
+    })
+
+    test('JSON without a string `_type` degrades to a code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = ['```json:object', '{"sku": "abc-123"}', '```'].join(
+        '\n',
+      )
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '{"sku": "abc-123"}',
+          language: 'json:object',
+        },
+      ])
+    })
+
+    test('a tagged inline code span reconstructs an inline object in place', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown =
+        'AAPL is at json:object`{"_type":"stockTicker","_key":"t1","symbol":"AAPL"}` right now.'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'AAPL is at ', marks: []},
+            {_type: 'stockTicker', _key: 't1', symbol: 'AAPL'},
+            {_type: 'span', _key: 'k2', text: ' right now.', marks: []},
+          ],
+        },
+      ])
+    })
+
+    test('an inline payload without a `_key` stays keyless', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = 'json:object`{"_type":"stockTicker","symbol":"AAPL"}`'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'stockTicker', symbol: 'AAPL'}],
+        },
+      ])
+    })
+
+    test('a space between the tag and the code span prevents binding', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = 'json:object `{"_type":"stockTicker"}`'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'json:object ', marks: []},
+            {
+              _type: 'span',
+              _key: 'k2',
+              text: '{"_type":"stockTicker"}',
+              marks: ['code'],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('a tagged code span without a string `_type` stays a code span', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = 'json:object`{"symbol":"AAPL"}`'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'json:object', marks: []},
+            {
+              _type: 'span',
+              _key: 'k2',
+              text: '{"symbol":"AAPL"}',
+              marks: ['code'],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('a pretty-printed payload in a tagged span still reconstructs', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown =
+        'json:object`{\n  "_type": "stockTicker",\n  "_key": "t1",\n  "symbol": "AAPL"\n}`'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'stockTicker', _key: 't1', symbol: 'AAPL'}],
+        },
+      ])
+    })
+
+    test('a fence inside a blockquote reconstructs inside the quote content', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = [
+        '> quoted',
+        '>',
+        '> ```json:object',
+        '> {"_type": "product", "_key": "p1", "sku": "abc-123"}',
+        '> ```',
+      ].join('\n')
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'blockquote',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: 'quoted', marks: []}],
+        },
+        {_type: 'product', _key: 'p1', sku: 'abc-123'},
+      ])
+    })
+
+    test('emphasis around a tagged span binds the object and drops the emphasis', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = '*json:object`{"_type":"stockTicker","_key":"t1"}`*'
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'stockTicker', _key: 't1'}],
+        },
+      ])
+    })
+
+    test('a JSON array degrades to a code block', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = ['```json:object', '[{"_type": "product"}]', '```'].join(
+        '\n',
+      )
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '[{"_type": "product"}]',
+          language: 'json:object',
+        },
+      ])
+    })
+  })
 })

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1225,9 +1225,11 @@ describe(portableTextToMarkdown.name, () => {
 
       const jsonLines = JSON.stringify(malformedCode, null, 2).split('\n')
       expect(portableTextToMarkdown([value], outOpts)).toBe(
-        ['> ```json', ...jsonLines.map((line) => `> ${line}`), '> ```'].join(
-          '\n',
-        ),
+        [
+          '> ```json:object',
+          ...jsonLines.map((line) => `> ${line}`),
+          '> ```',
+        ].join('\n'),
       )
     })
 
@@ -1391,7 +1393,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'image', _key: keyGenerator(), alt: 'foo'}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -1404,7 +1406,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'image', _key: keyGenerator(), ...image}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -1590,7 +1592,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'code', _key: keyGenerator(), language: 'js'}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -1599,7 +1601,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'code', _key: keyGenerator(), code: 42}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -1665,7 +1667,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'html', _key: keyGenerator()}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -1674,7 +1676,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'html', _key: keyGenerator(), html: 42}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
   })
@@ -1721,7 +1723,7 @@ describe(portableTextToMarkdown.name, () => {
 
       test('`types: {table: undefined}` opts out and falls back to fenced JSON', () => {
         const markdownOut = [
-          '```json',
+          '```json:object',
           JSON.stringify(portableText.at(0), null, 2),
           '```',
         ].join('\n')
@@ -2930,7 +2932,7 @@ describe(portableTextToMarkdown.name, () => {
         const value = {_type: 'table', _key: keyGenerator(), headerRows: 1}
 
         expect(portableTextToMarkdown([value])).toBe(
-          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+          ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
         )
       })
 
@@ -2944,7 +2946,7 @@ describe(portableTextToMarkdown.name, () => {
         const value = {_type: 'table', _key: keyGenerator(), ...table}
 
         expect(portableTextToMarkdown([value])).toBe(
-          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+          ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
         )
       })
 
@@ -3040,7 +3042,7 @@ describe(portableTextToMarkdown.name, () => {
       const value = {_type: 'callout', _key: keyGenerator(), content: []}
 
       expect(portableTextToMarkdown([value])).toBe(
-        ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
       )
     })
 
@@ -3058,7 +3060,7 @@ describe(portableTextToMarkdown.name, () => {
         const value = {_type: 'callout', _key: keyGenerator(), ...callout}
 
         expect(portableTextToMarkdown([value])).toBe(
-          ['```json', JSON.stringify(value, null, 2), '```'].join('\n'),
+          ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
         )
       },
     )
@@ -3077,7 +3079,7 @@ describe(portableTextToMarkdown.name, () => {
       expect(portableTextToMarkdown([value])).toBe(
         [
           '> [!NOTE]',
-          '> ```json',
+          '> ```json:object',
           ...jsonLines.map((line) => `> ${line}`),
           '> ```',
         ].join('\n'),
@@ -4133,6 +4135,219 @@ describe(portableTextToMarkdown.name, () => {
       })
 
       expect(portableTextToMarkdown(portableText)).toBe(markdown)
+    })
+  })
+  describe('unknown block object (`json:object` fence)', () => {
+    test('serializes as a `json:object` fence with the value as pretty JSON', () => {
+      const value = {
+        _type: 'product',
+        _key: 'product-key',
+        sku: 'abc-123',
+      }
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('round-trips back to the same object, `_key` included', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'product',
+        _key: 'product-key',
+        sku: 'abc-123',
+        nested: {_type: 'variant', _key: 'variant-key', size: 'L'},
+      }
+      expect(
+        markdownToPortableText(portableTextToMarkdown([value]), {
+          keyGenerator,
+        }),
+      ).toEqual([value])
+    })
+
+    test('the serialized fence is a markdown fixpoint', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = portableTextToMarkdown([
+        {_type: 'product', _key: 'product-key', sku: 'abc-123'},
+      ])
+      expect(
+        portableTextToMarkdown(
+          markdownToPortableText(markdown, {keyGenerator}),
+        ),
+      ).toBe(markdown)
+    })
+
+    test('an inline unknown object serializes as a tagged code span in the line', () => {
+      const value = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 's1', text: 'before ', marks: []},
+            {_type: 'stockTicker', _key: 't1', symbol: 'AAPL'},
+            {_type: 'span', _key: 's2', text: ' after', marks: []},
+          ],
+        },
+      ]
+      expect(portableTextToMarkdown(value)).toBe(
+        'before json:object`{"_type":"stockTicker","_key":"t1","symbol":"AAPL"}` after',
+      )
+    })
+
+    test('an inline payload containing backticks widens the code span', () => {
+      const value = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 's1', text: 'x ', marks: []},
+            {_type: 'snippet', _key: 't1', code: 'a `b` c'},
+          ],
+        },
+      ]
+      expect(portableTextToMarkdown(value)).toBe(
+        'x json:object``{"_type":"snippet","_key":"t1","code":"a `b` c"}``',
+      )
+    })
+
+    test('an inline unknown object round-trips in place, `_key` included', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = [
+        {
+          _type: 'block',
+          _key: 'b1',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 's1', text: 'AAPL is at ', marks: []},
+            {_type: 'stockTicker', _key: 't1', symbol: 'AAPL'},
+            {_type: 'span', _key: 's2', text: ' right now.', marks: []},
+          ],
+        },
+      ]
+      expect(
+        markdownToPortableText(portableTextToMarkdown(value), {keyGenerator}),
+      ).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: 'k1', text: 'AAPL is at ', marks: []},
+            {_type: 'stockTicker', _key: 't1', symbol: 'AAPL'},
+            {_type: 'span', _key: 'k2', text: ' right now.', marks: []},
+          ],
+        },
+      ])
+    })
+
+    test('a code block whose `language` is `json:object` drops the language instead of becoming an object', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = [
+        {
+          _type: 'code',
+          _key: 'c1',
+          language: 'json:object',
+          code: '{"_type": "x", "a": 1}',
+        },
+      ]
+      expect(portableTextToMarkdown(value)).toBe(
+        ['```', '{"_type": "x", "a": 1}', '```'].join('\n'),
+      )
+      expect(
+        markdownToPortableText(portableTextToMarkdown(value), {keyGenerator}),
+      ).toEqual([
+        {
+          _type: 'code',
+          _key: 'k0',
+          code: '{"_type": "x", "a": 1}',
+        },
+      ])
+    })
+
+    test('an inline object inside a table cell round-trips, pipes in the payload included', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = [
+        {
+          _type: 'table',
+          _key: 'tbl1',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 's1', text: 'sym ', marks: []},
+                        {_type: 'stockTicker', _key: 't1', symbol: 'A|B'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      const roundTripped = markdownToPortableText(
+        portableTextToMarkdown(value),
+        {keyGenerator},
+      )
+      expect(roundTripped).toEqual([
+        {
+          _type: 'table',
+          _key: 'k4',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k3',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k2',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'k0',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'span', _key: 'k1', text: 'sym ', marks: []},
+                        {_type: 'stockTicker', _key: 't1', symbol: 'A|B'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('the serialized inline form is a markdown fixpoint', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown =
+        'AAPL is at json:object`{"_type":"stockTicker","_key":"t1","symbol":"AAPL"}` right now.'
+      expect(
+        portableTextToMarkdown(
+          markdownToPortableText(markdown, {keyGenerator}),
+        ),
+      ).toBe(markdown)
     })
   })
 })

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -1011,6 +1011,15 @@ export function markdownToPortableText(
         // Remove trailing newline from code content
         const code = token.content.replace(/\n$/, '')
 
+        if (language === 'json:object') {
+          const objectValue = parseJsonObjectFence(code)
+
+          if (objectValue) {
+            pushBlock(objectValue as PortableTextObject)
+            break
+          }
+        }
+
         const codeObject = consolidatedOptions.types.code({
           context: {
             schema: consolidatedOptions.schema,
@@ -1469,11 +1478,52 @@ export function markdownToPortableText(
         }
 
         // Walk its children for text/marks/links
-        for (const childToken of token.children ?? []) {
+        const inlineChildren = token.children ?? []
+        for (
+          let childIndex = 0;
+          childIndex < inlineChildren.length;
+          childIndex++
+        ) {
+          const childToken = inlineChildren[childIndex]
+
+          if (!childToken) {
+            continue
+          }
+
           switch (childToken.type) {
-            case 'text':
+            case 'text': {
+              const nextToken = inlineChildren[childIndex + 1]
+
+              if (
+                childToken.content.endsWith('json:object') &&
+                nextToken?.type === 'code_inline' &&
+                currentBlock &&
+                'children' in currentBlock
+              ) {
+                const objectValue = parseJsonObjectFence(nextToken.content)
+
+                if (objectValue) {
+                  const prefix = childToken.content.slice(
+                    0,
+                    -'json:object'.length,
+                  )
+
+                  if (prefix.length > 0) {
+                    addSpan(prefix)
+                  }
+
+                  ;(currentBlock as PortableTextTextBlock).children.push(
+                    objectValue as PortableTextObject,
+                  )
+
+                  childIndex++
+                  break
+                }
+              }
+
               addSpan(childToken.content)
               break
+            }
             case 'softbreak':
               addSpan(' ')
               break
@@ -1812,4 +1862,38 @@ export function markdownToPortableText(
   flushBlock()
 
   return portableText
+}
+
+/**
+ * A `json:object` fence always reconstructs its object, schema or no
+ * schema: the fence carries its own `_type`, and degrading it to a code
+ * block would reintroduce the loss the syntax exists to remove. Returns
+ * `undefined` instead of throwing, so an unusable fence falls through to
+ * the regular code path.
+ */
+function parseJsonObjectFence(
+  code: string,
+): (Record<string, unknown> & {_type: string}) | undefined {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(code)
+  } catch {
+    return undefined
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return undefined
+  }
+
+  const objectValue = parsed as Record<string, unknown>
+
+  if (
+    typeof objectValue['_type'] !== 'string' ||
+    objectValue['_type'].length === 0
+  ) {
+    return undefined
+  }
+
+  return objectValue as Record<string, unknown> & {_type: string}
 }


### PR DESCRIPTION
Converting Portable Text to markdown and back destroys custom objects. The serializer's unknown-type fallback emits a ` ```json ` fence, and re-parsing turns that fence into a `code` block, losing the `_type`, the fields, and the `_key`. Inline objects degrade worse: the fence breaks out of the text flow, so the value also loses its position and splits its host block into three. That loss is why editing Portable Text through markdown is off-limits for agent tooling: a read-modify-write loop through markdown wipes every custom object in the document.

Unknown objects now round-trip at both levels. A block-level object serializes as a fence with a `json:object` info string; an inline object serializes as a `json:object`-tagged inline code span, single-line JSON, staying inside its line. The parser reconstructs both into the objects they came from before any code-block handling runs. Reconstruction is pure transport: the fence and the span carry their own `_type`, neither the schema nor the type name gates it, and the payload comes back exactly as written, `_key` kept when present, nothing added when absent, duplicates not policed (uniqueness is sibling-scoped and owned downstream); validation stays where it lives for every other construct. Pinned by round-trip and fixpoint tests at both levels, including objects in blockquotes and in table cells (with `|` in a cell payload, which the cell escaping and markdown-it's cell splitting cancel out), and a pretty-printed hand-written payload; those fail on the pre-change code. The degradation tests (non-object bodies stay ordinary code) and binding negative tests (a space between tag and span prevents binding) pin boundary behavior the change preserves.

One guard bounds the carrier itself, pinned: the `json:object` info string is reserved, so a real `code` object with that literal language loses the language (not the code) instead of re-parsing as an embedded object whenever its content happens to be typed JSON.

Two edges are accepted and pinned rather than fixed: plain text ending in `json:object` immediately followed by a code-marked span whose content is a typed JSON object parses as an inline object (escapes resolve before the token-level binding, so the escaping engine cannot mask it), and marks around such a hand-written span are dropped. The serializer never emits either shape.

Validating payloads against a schema is deliberately out of scope: this PR is the carrier. The feat commit updates the package README's round-trip summary; a `docs:` commit updates the canonical round-tripping page and the rendering-page mentions, so the site describes this behavior once it releases.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default Markdown output and parsing for unknown types and fenced `json:object` content, which can break consumers that assumed ` ```json ` fences or treat all fences as code blocks; edge-case inline binding around the reserved `json:object` prefix is also behaviorally sensitive.
> 
> **Overview**
> **Unknown Portable Text objects can survive Markdown conversion in both directions.** `@portabletext/markdown` now emits block-level unrecognized types as ` ```json:object ` fences (replacing ` ```json `) and inline types as `json:object` plus a single-line JSON code span in the same line, instead of breaking inline content out with newlines.
> 
> **`markdownToPortableText` reconstructs those carriers** into the original typed objects (including `_key` when present) before normal code-block handling, without requiring schema support. Invalid or untyped JSON still becomes an ordinary `code` block or inline code mark.
> 
> **Guards and contract updates:** real `code` blocks whose `language` is `json:object` serialize with an empty info string so typed JSON in the body cannot be mistaken for an embedded object. Docs, README, and changeset describe round-trip behavior, fixpoint exceptions (tagged-span adjacency), and the minor output change for unknown-type fallbacks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 591a6655bc5a5b80a5c00179d5ea82a990799de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->