### PR TITLE
feat(playground): add a `/markdown` conversion test bench

### DIFF
--- a/apps/playground/package.json
+++ b/apps/playground/package.json
@@ -28,6 +28,7 @@
     "@portabletext/plugin-typeahead-picker": "workspace:*",
     "@portabletext/plugin-typography": "workspace:*",
     "@portabletext/react": "catalog:tooling",
+    "@portabletext/schema": "workspace:*",
     "@portabletext/toolbar": "workspace:*",
     "@tanstack/react-router": "^1.170.32",
     "@xstate/react": "catalog:",

--- a/apps/playground/src/markdown-bench/editor-nodes.tsx
+++ b/apps/playground/src/markdown-bench/editor-nodes.tsx
@@ -1,0 +1,416 @@
+import {
+  defineAnnotation,
+  defineBlockObject,
+  defineContainer,
+  defineDecorator,
+  defineInlineObject,
+  defineTextBlock,
+  useEditor,
+  type AnnotationRenderProps,
+  type BlockObjectRenderProps,
+  type BlockPath,
+  type ContainerRenderProps,
+  type DecoratorRenderProps,
+  type InlineObjectRenderProps,
+  type PortableTextBlock,
+  type RegistrableNode,
+  type RenderPlaceholderFunction,
+  type TextBlockRenderProps,
+} from '@portabletext/editor'
+import {useListIndex} from '@portabletext/plugin-list-index'
+import type {MarkdownShortcutsPluginProps} from '@portabletext/plugin-markdown-shortcuts'
+import {defineTable} from '@portabletext/plugin-table'
+import {referenceContainers} from '@portabletext/plugin-table/ui'
+import {
+  InfoIcon,
+  LightbulbIcon,
+  MessageSquareWarningIcon,
+  OctagonAlertIcon,
+  TriangleAlertIcon,
+} from 'lucide-react'
+import type {JSX} from 'react'
+import type {MarkdownBenchFeatures} from './schema'
+
+export const markdownShortcutsProps: MarkdownShortcutsPluginProps = {
+  boldDecorator: ({context}) =>
+    context.schema.decorators.find((decorator) => decorator.name === 'strong')
+      ?.name,
+  codeDecorator: ({context}) =>
+    context.schema.decorators.find((decorator) => decorator.name === 'code')
+      ?.name,
+  italicDecorator: ({context}) =>
+    context.schema.decorators.find((decorator) => decorator.name === 'em')
+      ?.name,
+  strikeThroughDecorator: ({context}) =>
+    context.schema.decorators.find(
+      (decorator) => decorator.name === 'strike-through',
+    )?.name,
+  horizontalRuleObject: ({context}) => {
+    const schemaType = context.schema.blockObjects.find(
+      (object) => object.name === 'horizontal-rule',
+    )
+    return schemaType ? {_type: schemaType.name} : undefined
+  },
+  linkObject: ({context, props}) => {
+    const schemaType = context.schema.annotations.find(
+      (annotation) => annotation.name === 'link',
+    )
+    const hrefField = schemaType?.fields.find(
+      (field) => field.name === 'href' && field.type === 'string',
+    )
+    if (!schemaType || !hrefField) {
+      return undefined
+    }
+    return {_type: schemaType.name, [hrefField.name]: props.href}
+  },
+  defaultStyle: ({context}) => context.schema.styles[0]?.name,
+  headingStyle: ({context, props}) =>
+    context.schema.styles.find((style) => style.name === `h${props.level}`)
+      ?.name,
+  blockquoteStyle: ({context}) =>
+    context.schema.styles.find((style) => style.name === 'blockquote')?.name,
+  unorderedList: ({context}) =>
+    context.schema.lists.find((list) => list.name === 'bullet')?.name,
+  orderedList: ({context}) =>
+    context.schema.lists.find((list) => list.name === 'number')?.name,
+}
+
+export const renderPlaceholder: RenderPlaceholderFunction = () => (
+  <span className="text-gray-400 dark:text-gray-500">
+    Type or paste markdown
+  </span>
+)
+
+// `defineTable` registers the table type names (`table`/`row`/`cell`) in a
+// module-level registry the reference UI reads from outside the render
+// tree; the registration is the same regardless of `features`, so it runs
+// once here rather than on every `buildEditorNodes` call.
+const table = defineTable({containers: referenceContainers})
+
+export function buildEditorNodes(features: MarkdownBenchFeatures): {
+  nodes: Array<RegistrableNode>
+  tablePlugin: (() => JSX.Element) | null
+} {
+  const nodes: Array<RegistrableNode> = [
+    defineTextBlock({type: 'block', render: TextBlock}),
+    defineDecorator({type: '*', render: Decorator}),
+    defineAnnotation({type: 'link', render: LinkAnnotation}),
+    defineBlockObject({type: 'horizontal-rule', render: HorizontalRule}),
+    defineBlockObject({type: 'html', render: HtmlBlock}),
+  ]
+
+  if (features.code) {
+    nodes.push(defineBlockObject({type: 'code', render: CodeBlock}))
+  }
+  if (features.image) {
+    nodes.push(defineBlockObject({type: 'image', render: ImageBlock}))
+    nodes.push(defineInlineObject({type: 'image', render: InlineImage}))
+  }
+  if (features.callout) {
+    nodes.push(
+      defineContainer({
+        type: 'callout',
+        arrayField: 'content',
+        render: CalloutContainer,
+      }),
+    )
+  }
+
+  return {nodes, tablePlugin: features.table ? table.Plugin : null}
+}
+
+function TextBlock(props: TextBlockRenderProps): JSX.Element {
+  if (props.node.listItem !== undefined) {
+    return <ListItemBlock {...props} />
+  }
+  return renderStyledBlock(props.node.style, props)
+}
+
+function ListItemBlock(props: TextBlockRenderProps): JSX.Element {
+  const listIndex = useListIndex(props.path)
+  const checked = (props.node as {checked?: boolean}).checked === true
+  const children =
+    props.node.listItem === 'task' ? (
+      <span
+        className="flex items-center gap-2 data-[checked=true]:text-gray-400 data-[checked=true]:line-through [&>*:last-child]:flex-1"
+        data-checked={checked}
+      >
+        <TaskListCheckbox node={props.node} path={props.path} />
+        {props.children}
+      </span>
+    ) : (
+      props.children
+    )
+  return (
+    <div
+      {...props.attributes}
+      data-list-item={props.node.listItem}
+      data-level={props.node.level}
+      data-list-index={listIndex}
+      className="my-1"
+    >
+      {children}
+    </div>
+  )
+}
+
+function TaskListCheckbox(props: {
+  node: PortableTextBlock
+  path: BlockPath
+}): JSX.Element {
+  const editor = useEditor()
+  const checked = (props.node as {checked?: boolean}).checked === true
+  return (
+    <button
+      type="button"
+      contentEditable={false}
+      className="inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-gray-400 align-middle transition-colors hover:bg-gray-100 data-[checked=true]:border-blue-500 data-[checked=true]:bg-blue-500 dark:border-gray-600 dark:hover:bg-gray-700"
+      data-checked={checked}
+      onMouseDown={(event) => event.preventDefault()}
+      onClick={() =>
+        editor.send({
+          type: 'block.set',
+          props: {checked: !checked},
+          at: props.path,
+        })
+      }
+      aria-label={checked ? 'Mark task as not done' : 'Mark task as done'}
+    >
+      {checked ? <CheckMark /> : null}
+    </button>
+  )
+}
+
+function CheckMark(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 16 16"
+      className="size-3 fill-none stroke-white stroke-2"
+      aria-hidden
+    >
+      <path d="M3 8l3 3 7-7" />
+    </svg>
+  )
+}
+
+function renderStyledBlock(
+  style: string | undefined,
+  props: TextBlockRenderProps,
+): JSX.Element {
+  switch (style) {
+    case 'h1':
+      return (
+        <h1 {...props.attributes} className="my-2 font-bold text-3xl">
+          {props.children}
+        </h1>
+      )
+    case 'h2':
+      return (
+        <h2 {...props.attributes} className="my-2 font-bold text-2xl">
+          {props.children}
+        </h2>
+      )
+    case 'h3':
+      return (
+        <h3 {...props.attributes} className="my-2 font-bold text-xl">
+          {props.children}
+        </h3>
+      )
+    case 'h4':
+      return (
+        <h4 {...props.attributes} className="my-1 font-bold text-lg">
+          {props.children}
+        </h4>
+      )
+    case 'h5':
+      return (
+        <h5 {...props.attributes} className="my-1 font-bold text-base">
+          {props.children}
+        </h5>
+      )
+    case 'h6':
+      return (
+        <h6 {...props.attributes} className="my-1 font-bold text-sm">
+          {props.children}
+        </h6>
+      )
+    case 'blockquote':
+      return (
+        <blockquote
+          {...props.attributes}
+          className="my-1 border-l-4 border-gray-300 py-1 pl-2 dark:border-gray-600"
+        >
+          {props.children}
+        </blockquote>
+      )
+    default:
+      return (
+        <p {...props.attributes} className="my-1">
+          {props.children}
+        </p>
+      )
+  }
+}
+
+function Decorator(props: DecoratorRenderProps): JSX.Element {
+  switch (props.decorator) {
+    case 'strong':
+      return <strong>{props.children}</strong>
+    case 'em':
+      return <em>{props.children}</em>
+    case 'code':
+      return (
+        <code className="rounded border border-gray-200 bg-gray-100 px-1 py-0.5 font-mono text-sm text-pink-600 dark:border-gray-700 dark:bg-gray-800 dark:text-pink-400">
+          {props.children}
+        </code>
+      )
+    case 'strike-through':
+      return <span className="line-through">{props.children}</span>
+    default:
+      return props.children
+  }
+}
+
+function LinkAnnotation(props: AnnotationRenderProps): JSX.Element {
+  return (
+    <span className="text-blue-700 underline dark:text-blue-400">
+      {props.children}
+    </span>
+  )
+}
+
+function HorizontalRule(props: BlockObjectRenderProps): JSX.Element {
+  return (
+    <div {...props.attributes} className="my-6 flex items-center">
+      {props.children}
+      <div
+        contentEditable={false}
+        className="h-px w-full bg-gray-300 dark:bg-gray-600"
+      />
+    </div>
+  )
+}
+
+function HtmlBlock(props: BlockObjectRenderProps): JSX.Element {
+  const html = (props.node as {html?: string}).html ?? ''
+  return (
+    <div {...props.attributes} className="my-2">
+      {props.children}
+      <pre
+        contentEditable={false}
+        className="overflow-x-auto rounded border border-dashed border-gray-300 bg-gray-50 p-2 font-mono text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-300"
+      >
+        {html}
+      </pre>
+    </div>
+  )
+}
+
+function CodeBlock(props: BlockObjectRenderProps): JSX.Element {
+  const value = props.node as {language?: string; code?: string}
+  return (
+    <div {...props.attributes} className="my-2">
+      {props.children}
+      <pre
+        contentEditable={false}
+        className="overflow-x-auto rounded bg-gray-100 p-2 font-mono text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200"
+      >
+        {value.language ? (
+          <div className="mb-1 text-gray-400 dark:text-gray-500">
+            {value.language}
+          </div>
+        ) : null}
+        <code>{value.code ?? ''}</code>
+      </pre>
+    </div>
+  )
+}
+
+function ImageBlock(props: BlockObjectRenderProps): JSX.Element {
+  const value = props.node as {src?: string; alt?: string}
+  return (
+    <div
+      {...props.attributes}
+      className="my-2 grid grid-cols-[auto_1fr] items-start gap-2 rounded border border-gray-300 p-1 dark:border-gray-600"
+    >
+      {props.children}
+      <div className="flex size-20 shrink-0 items-center justify-center overflow-hidden rounded bg-gray-100 dark:bg-gray-700">
+        <img
+          src={value.src}
+          alt={value.alt ?? ''}
+          contentEditable={false}
+          className="max-h-full max-w-full object-scale-down"
+        />
+      </div>
+      <span className="self-center overflow-hidden text-ellipsis whitespace-nowrap text-xs text-gray-500 dark:text-gray-400">
+        {value.alt || value.src}
+      </span>
+    </div>
+  )
+}
+
+function InlineImage(props: InlineObjectRenderProps): JSX.Element {
+  const value = props.node as {src?: string; alt?: string}
+  return (
+    <span
+      {...props.attributes}
+      className="mx-0.5 inline-flex size-5 items-center justify-center overflow-hidden rounded border border-gray-300 align-text-bottom dark:border-gray-600"
+    >
+      {props.children}
+      <img
+        src={value.src}
+        alt={value.alt ?? ''}
+        contentEditable={false}
+        className="max-h-full max-w-full object-cover"
+      />
+    </span>
+  )
+}
+
+const toneClassName: Record<string, string> = {
+  note: 'border-sky-400 bg-sky-50 text-sky-900 dark:bg-sky-950/40 dark:text-sky-100',
+  tip: 'border-emerald-400 bg-emerald-50 text-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100',
+  important:
+    'border-violet-400 bg-violet-50 text-violet-900 dark:bg-violet-950/40 dark:text-violet-100',
+  warning:
+    'border-amber-400 bg-amber-50 text-amber-900 dark:bg-amber-950/40 dark:text-amber-100',
+  caution:
+    'border-rose-400 bg-rose-50 text-rose-900 dark:bg-rose-950/40 dark:text-rose-100',
+}
+
+const defaultToneClassName = toneClassName.note!
+
+function ToneIcon(props: {tone: string}): JSX.Element {
+  const className = 'size-4 shrink-0'
+  switch (props.tone) {
+    case 'tip':
+      return <LightbulbIcon aria-hidden className={className} />
+    case 'important':
+      return <MessageSquareWarningIcon aria-hidden className={className} />
+    case 'warning':
+      return <TriangleAlertIcon aria-hidden className={className} />
+    case 'caution':
+      return <OctagonAlertIcon aria-hidden className={className} />
+    default:
+      return <InfoIcon aria-hidden className={className} />
+  }
+}
+
+function CalloutContainer(props: ContainerRenderProps): JSX.Element {
+  const tone = typeof props.node.tone === 'string' ? props.node.tone : 'note'
+  const toneStyle = toneClassName[tone] ?? defaultToneClassName
+  return (
+    <aside
+      {...props.attributes}
+      className={`my-3 flex gap-2.5 rounded-md border-l-4 p-3 ${toneStyle}`}
+    >
+      <span
+        contentEditable={false}
+        className="mt-[0.2rem] flex shrink-0 items-center justify-center"
+      >
+        <ToneIcon tone={tone} />
+      </span>
+      <div className="min-w-0 flex-1">{props.children}</div>
+    </aside>
+  )
+}

--- a/apps/playground/src/markdown-bench/markdown-bench.tsx
+++ b/apps/playground/src/markdown-bench/markdown-bench.tsx
@@ -1,0 +1,480 @@
+import '@portabletext/plugin-table/ui/styles.css'
+import '../editor.css'
+import {
+  EditorProvider,
+  PortableTextEditable,
+  type Editor,
+  type PortableTextBlock,
+} from '@portabletext/editor'
+import {
+  EditorRefPlugin,
+  EventListenerPlugin,
+  NodePlugin,
+} from '@portabletext/editor/plugins'
+import {
+  markdownToPortableText,
+  portableTextToMarkdown,
+} from '@portabletext/markdown'
+import {ListIndexProvider} from '@portabletext/plugin-list-index'
+import {MarkdownShortcutsPlugin} from '@portabletext/plugin-markdown-shortcuts'
+import {compileSchema} from '@portabletext/schema'
+import {useEffect, useMemo, useRef, useState} from 'react'
+import {createKeyGenerator} from '../key-generator'
+import {PageNav} from '../page-nav'
+import {
+  buildEditorNodes,
+  markdownShortcutsProps,
+  renderPlaceholder,
+} from './editor-nodes'
+import {
+  buildToMarkdownOptions,
+  buildToPortableTextOptions,
+  emptyCodeOptions,
+  errorMessage,
+  evaluateOptionsSource,
+  type CompiledCodeOptions,
+} from './options'
+import {loadPersistedState, savePersistedState} from './persistence'
+import {
+  defaultFeatures,
+  featureLabels,
+  buildSchemaDefinition,
+  type MarkdownBenchFeatures,
+} from './schema'
+import seedMarkdown from './seed.md?raw'
+import {defaultSnippet, optionsSnippets} from './snippets'
+
+/**
+ * The parsed value and any parse error for one `(features, htmlInlineMode,
+ * code, markdown)` combination.
+ */
+function computeEditorInit(args: {
+  features: MarkdownBenchFeatures
+  htmlInlineMode: 'skip' | 'text'
+  code: CompiledCodeOptions
+  markdown: string
+}): {blocks: Array<PortableTextBlock>; error: string | null} {
+  try {
+    const schema = compileSchema(
+      buildSchemaDefinition(args.features, args.code.schemaTypes?.blockObjects),
+    )
+    const options = buildToPortableTextOptions({
+      schema,
+      htmlInlineMode: args.htmlInlineMode,
+      code: args.code,
+    })
+    return {blocks: markdownToPortableText(args.markdown, options), error: null}
+  } catch (err) {
+    return {blocks: [], error: errorMessage(err)}
+  }
+}
+
+export function MarkdownBench() {
+  const [persisted] = useState(() => loadPersistedState())
+  const initial = useMemo(() => {
+    const initialMarkdown = persisted?.markdown ?? seedMarkdown
+    const initialFeatures = persisted?.features ?? defaultFeatures
+    const initialHtmlInlineMode = persisted?.htmlInlineMode ?? 'skip'
+    const initialCodeSource = persisted?.codeSource ?? defaultSnippet.source
+    return {
+      initialMarkdown,
+      initialFeatures,
+      initialHtmlInlineMode,
+      initialCodeSource,
+    }
+  }, [persisted])
+
+  const [markdown, setMarkdown] = useState(initial.initialMarkdown)
+  const [features, setFeatures] = useState(initial.initialFeatures)
+  const [htmlInlineMode, setHtmlInlineMode] = useState(
+    initial.initialHtmlInlineMode,
+  )
+  const [codeSource, setCodeSource] = useState(initial.initialCodeSource)
+  const [compiledCode, setCompiledCode] = useState<CompiledCodeOptions>(() => {
+    try {
+      return evaluateOptionsSource(initial.initialCodeSource)
+    } catch {
+      return emptyCodeOptions
+    }
+  })
+  // Every path that changes conversion options (a schema toggle, the inline
+  // HTML mode, an options-pane apply, reset) bumps this alongside the state
+  // it derives from: the focus gate and the handlers below assume the
+  // options in scope and the mounted editor instance always swap together.
+  const [editorGeneration, setEditorGeneration] = useState(0)
+  const [editorInit, setEditorInit] = useState(() =>
+    computeEditorInit({
+      features: initial.initialFeatures,
+      htmlInlineMode: initial.initialHtmlInlineMode,
+      code: compiledCode,
+      markdown: initial.initialMarkdown,
+    }),
+  )
+  const [error, setError] = useState<string | null>(editorInit.error)
+
+  const focused = useRef<'editor' | 'markdown' | null>(null)
+  const editorRef = useRef<Editor | null>(null)
+
+  const definition = useMemo(
+    () =>
+      buildSchemaDefinition(features, compiledCode.schemaTypes?.blockObjects),
+    [features, compiledCode],
+  )
+  const schema = useMemo(() => compileSchema(definition), [definition])
+  const {nodes, tablePlugin: TablePlugin} = useMemo(
+    () => buildEditorNodes(features),
+    [features],
+  )
+
+  const toPortableTextOptions = useMemo(
+    () =>
+      buildToPortableTextOptions({schema, htmlInlineMode, code: compiledCode}),
+    [schema, htmlInlineMode, compiledCode],
+  )
+  const toMarkdownOptions = useMemo(
+    () => buildToMarkdownOptions(compiledCode),
+    [compiledCode],
+  )
+
+  const editorKey = String(editorGeneration)
+  const [editorKeyGenerator] = useState(() =>
+    createKeyGenerator('markdown-bench-editor'),
+  )
+
+  useEffect(() => {
+    savePersistedState({markdown, codeSource, features, htmlInlineMode})
+  }, [markdown, codeSource, features, htmlInlineMode])
+
+  function syncMarkdownFromEditorValue(value: Array<PortableTextBlock>) {
+    try {
+      setMarkdown(portableTextToMarkdown(value, toMarkdownOptions))
+      setError(null)
+    } catch (err) {
+      setError(errorMessage(err))
+    }
+  }
+
+  function handleMarkdownChange(text: string) {
+    setMarkdown(text)
+    if (focused.current !== 'markdown') {
+      return
+    }
+    try {
+      const blocks = markdownToPortableText(text, toPortableTextOptions)
+      editorRef.current?.send({type: 'update value', value: blocks})
+      setError(null)
+    } catch (err) {
+      setError(errorMessage(err))
+    }
+  }
+
+  function handleEditorMutation(nextValue: Array<PortableTextBlock>) {
+    // `update value` (the markdown pane's own writes back to the editor)
+    // emits no `mutation`, so this only ever fires for a real edit; dropping
+    // it while the textarea is the active writer is the only guard needed.
+    if (focused.current === 'markdown') {
+      return
+    }
+    syncMarkdownFromEditorValue(nextValue)
+  }
+
+  function handleFeaturesChange(nextFeatures: MarkdownBenchFeatures) {
+    const result = computeEditorInit({
+      features: nextFeatures,
+      htmlInlineMode,
+      code: compiledCode,
+      markdown,
+    })
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+    focused.current = null
+    setFeatures(nextFeatures)
+    setEditorInit(result)
+    setError(null)
+    setEditorGeneration((generation) => generation + 1)
+  }
+
+  function handleHtmlInlineChange(nextMode: 'skip' | 'text') {
+    const result = computeEditorInit({
+      features,
+      htmlInlineMode: nextMode,
+      code: compiledCode,
+      markdown,
+    })
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+    focused.current = null
+    setHtmlInlineMode(nextMode)
+    setEditorInit(result)
+    setError(null)
+    setEditorGeneration((generation) => generation + 1)
+  }
+
+  function applyOptionsSource() {
+    let compiled: CompiledCodeOptions
+    try {
+      compiled = evaluateOptionsSource(codeSource)
+    } catch (err) {
+      setError(errorMessage(err))
+      return
+    }
+    const result = computeEditorInit({
+      features,
+      htmlInlineMode,
+      code: compiled,
+      markdown,
+    })
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+    focused.current = null
+    setCompiledCode(compiled)
+    setEditorInit(result)
+    setError(null)
+    setEditorGeneration((generation) => generation + 1)
+  }
+
+  function handleReset() {
+    const result = computeEditorInit({
+      features: defaultFeatures,
+      htmlInlineMode: 'skip',
+      code: emptyCodeOptions,
+      markdown: seedMarkdown,
+    })
+    if (result.error) {
+      setError(result.error)
+      return
+    }
+    focused.current = null
+    setMarkdown(seedMarkdown)
+    setFeatures(defaultFeatures)
+    setHtmlInlineMode('skip')
+    setCodeSource(defaultSnippet.source)
+    setCompiledCode(emptyCodeOptions)
+    setEditorInit(result)
+    setError(null)
+    setEditorGeneration((generation) => generation + 1)
+  }
+
+  return (
+    <>
+      <header className="flex items-center justify-between px-3 md:px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+        <PageNav />
+        <button
+          type="button"
+          onClick={handleReset}
+          className="rounded-md px-2 py-1 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+        >
+          Reset
+        </button>
+      </header>
+      <main className="flex-1 flex flex-col min-h-0 min-w-0 gap-3 px-3 py-4 md:px-4">
+        <ErrorStrip message={error} />
+        <div className="grid flex-1 min-h-0 grid-cols-1 gap-3 lg:grid-cols-[2fr_2fr_1fr]">
+          <section className="min-h-0 overflow-y-auto rounded-md border border-gray-200 dark:border-gray-700">
+            <EditorProvider
+              key={editorKey}
+              initialConfig={{
+                schemaDefinition: definition,
+                initialValue: editorInit.blocks,
+                keyGenerator: editorKeyGenerator,
+              }}
+            >
+              <EventListenerPlugin
+                on={(event) => {
+                  if (event.type === 'mutation') {
+                    handleEditorMutation(event.value ?? [])
+                  }
+                }}
+              />
+              <NodePlugin nodes={nodes} />
+              {TablePlugin ? <TablePlugin /> : null}
+              <MarkdownShortcutsPlugin {...markdownShortcutsProps} />
+              <EditorRefPlugin ref={editorRef} />
+              <ListIndexProvider>
+                <PortableTextEditable
+                  onFocus={() => {
+                    focused.current = 'editor'
+                  }}
+                  renderPlaceholder={renderPlaceholder}
+                  className="prose prose-sm dark:prose-invert h-full max-w-none px-3 py-2 outline-none"
+                />
+              </ListIndexProvider>
+            </EditorProvider>
+          </section>
+          <section className="min-h-0 rounded-md border border-gray-200 dark:border-gray-700">
+            <textarea
+              value={markdown}
+              spellCheck={false}
+              onFocus={() => {
+                // Mutations are debounced (up to a 1s flush) and dropped
+                // while this textarea is focused, so an edit typed into the
+                // editor and not yet flushed would otherwise be silently
+                // lost the moment focus lands here. `getSnapshot().context`
+                // is the engine's live, synchronously-updated value (ahead
+                // of the debounced mutation batch); read it and hand it off
+                // to the markdown pane before flipping the gate.
+                const value = editorRef.current?.getSnapshot().context.value
+                if (value) {
+                  syncMarkdownFromEditorValue(value)
+                }
+                focused.current = 'markdown'
+              }}
+              onChange={(event) => handleMarkdownChange(event.target.value)}
+              className="h-full w-full resize-none bg-transparent p-3 font-mono text-xs text-gray-800 outline-none dark:text-gray-200"
+            />
+          </section>
+          <aside className="flex min-h-0 flex-col gap-3 overflow-y-auto">
+            <SchemaToggles
+              features={features}
+              onChange={handleFeaturesChange}
+            />
+            <HtmlInlineToggle
+              value={htmlInlineMode}
+              onChange={handleHtmlInlineChange}
+            />
+            <OptionsPane
+              source={codeSource}
+              onChange={setCodeSource}
+              onApply={applyOptionsSource}
+            />
+          </aside>
+        </div>
+      </main>
+    </>
+  )
+}
+
+function ErrorStrip(props: {message: string | null}) {
+  if (!props.message) {
+    return null
+  }
+  return (
+    <div className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-800 dark:border-red-800 dark:bg-red-950/40 dark:text-red-200">
+      {props.message}
+    </div>
+  )
+}
+
+function SchemaToggles(props: {
+  features: MarkdownBenchFeatures
+  onChange: (features: MarkdownBenchFeatures) => void
+}) {
+  const names = Object.keys(props.features) as Array<
+    keyof MarkdownBenchFeatures
+  >
+  return (
+    <div className="rounded-md border border-gray-200 p-3 dark:border-gray-700">
+      <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Schema features
+      </h2>
+      <div className="flex flex-col gap-1">
+        {names.map((name) => (
+          <label key={name} className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={props.features[name]}
+              onChange={(event) =>
+                props.onChange({
+                  ...props.features,
+                  [name]: event.target.checked,
+                })
+              }
+            />
+            {featureLabels[name]}
+          </label>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function HtmlInlineToggle(props: {
+  value: 'skip' | 'text'
+  onChange: (value: 'skip' | 'text') => void
+}) {
+  return (
+    <div className="rounded-md border border-gray-200 p-3 dark:border-gray-700">
+      <h2 className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+        Inline HTML
+      </h2>
+      <div className="flex gap-1">
+        {(['skip', 'text'] as const).map((mode) => (
+          <button
+            key={mode}
+            type="button"
+            onClick={() => props.onChange(mode)}
+            className={
+              props.value === mode
+                ? 'rounded-md bg-gray-800 px-2 py-1 text-xs text-white dark:bg-gray-200 dark:text-gray-900'
+                : 'rounded-md px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800'
+            }
+          >
+            {mode}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function OptionsPane(props: {
+  source: string
+  onChange: (source: string) => void
+  onApply: () => void
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col rounded-md border border-gray-200 p-3 dark:border-gray-700">
+      <div className="mb-2 flex items-center justify-between">
+        <h2 className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+          Options
+        </h2>
+        <select
+          value=""
+          onChange={(event) => {
+            const snippet = optionsSnippets.find(
+              (candidate) => candidate.id === event.target.value,
+            )
+            if (snippet) {
+              props.onChange(snippet.source)
+            }
+          }}
+          className="rounded-md border border-gray-200 bg-transparent px-1 py-0.5 text-xs dark:border-gray-700"
+        >
+          <option value="" disabled>
+            Load snippet…
+          </option>
+          {optionsSnippets.map((snippet) => (
+            <option key={snippet.id} value={snippet.id}>
+              {snippet.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        value={props.source}
+        spellCheck={false}
+        onChange={(event) => props.onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+            event.preventDefault()
+            props.onApply()
+          }
+        }}
+        className="min-h-40 flex-1 resize-none rounded-md border border-gray-200 bg-gray-50 p-2 font-mono text-xs text-gray-800 outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-gray-200"
+      />
+      <button
+        type="button"
+        onClick={props.onApply}
+        className="mt-2 self-start rounded-md bg-gray-800 px-2 py-1 text-xs text-white hover:bg-gray-700 dark:bg-gray-200 dark:text-gray-900 dark:hover:bg-gray-300"
+      >
+        Apply (⌘/Ctrl+Enter)
+      </button>
+    </div>
+  )
+}

--- a/apps/playground/src/markdown-bench/options.ts
+++ b/apps/playground/src/markdown-bench/options.ts
@@ -1,0 +1,94 @@
+import {defineSchema, type BlockObjectDefinition} from '@portabletext/editor'
+import * as markdownPackage from '@portabletext/markdown'
+import type {
+  markdownToPortableText,
+  portableTextToMarkdown,
+} from '@portabletext/markdown'
+import {compileSchema, type Schema} from '@portabletext/schema'
+import {createKeyGenerator} from '../key-generator'
+
+export type ToPortableTextOptions = NonNullable<
+  Parameters<typeof markdownToPortableText>[1]
+>
+export type ToMarkdownOptions = NonNullable<
+  Parameters<typeof portableTextToMarkdown>[1]
+>
+
+export type CompiledCodeOptions = {
+  toPortableText: Partial<ToPortableTextOptions>
+  toMarkdown: Partial<ToMarkdownOptions>
+  schemaTypes?: {
+    blockObjects?: ReadonlyArray<BlockObjectDefinition>
+  }
+}
+
+export const emptyCodeOptions: CompiledCodeOptions = {
+  toPortableText: {},
+  toMarkdown: {},
+}
+
+const codePaneHelpers = {
+  ...markdownPackage,
+  defineSchema,
+  compileSchema,
+  createKeyGenerator,
+}
+
+/**
+ * Evaluates the options pane source. The contract: the source is an
+ * expression (usually an object literal) evaluated with `helpers` in
+ * scope, optionally a function of `helpers` returning the options object,
+ * shaped `{toPortableText?, toMarkdown?, schemaTypes?}`.
+ */
+export function evaluateOptionsSource(source: string): CompiledCodeOptions {
+  const factory = new Function('helpers', `return (${source})`) as (
+    helpers: typeof codePaneHelpers,
+  ) => unknown
+  const result = factory(codePaneHelpers)
+  const options =
+    typeof result === 'function'
+      ? (result as (helpers: typeof codePaneHelpers) => unknown)(
+          codePaneHelpers,
+        )
+      : result
+
+  if (options === null || typeof options !== 'object') {
+    throw new Error(
+      'Options source must evaluate to an object (or a function of `helpers` returning one).',
+    )
+  }
+
+  const candidate = options as {
+    toPortableText?: Partial<ToPortableTextOptions>
+    toMarkdown?: Partial<ToMarkdownOptions>
+    schemaTypes?: {blockObjects?: ReadonlyArray<BlockObjectDefinition>}
+  }
+
+  return {
+    toPortableText: candidate.toPortableText ?? {},
+    toMarkdown: candidate.toMarkdown ?? {},
+    schemaTypes: candidate.schemaTypes,
+  }
+}
+
+export function buildToPortableTextOptions(args: {
+  schema: Schema
+  htmlInlineMode: 'skip' | 'text'
+  code: CompiledCodeOptions
+}): ToPortableTextOptions {
+  return {
+    schema: args.schema,
+    html: {inline: args.htmlInlineMode},
+    ...args.code.toPortableText,
+  }
+}
+
+export function buildToMarkdownOptions(
+  code: CompiledCodeOptions,
+): ToMarkdownOptions {
+  return {...code.toMarkdown}
+}
+
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/apps/playground/src/markdown-bench/persistence.ts
+++ b/apps/playground/src/markdown-bench/persistence.ts
@@ -1,0 +1,78 @@
+import type {MarkdownBenchFeatures} from './schema'
+
+const storageKey = 'portabletext-playground:markdown-bench'
+const persistedVersion = 1
+
+export type PersistedBenchState = {
+  markdown: string
+  codeSource: string
+  features: MarkdownBenchFeatures
+  htmlInlineMode: 'skip' | 'text'
+}
+
+const featureKeys: Array<keyof MarkdownBenchFeatures> = [
+  'table',
+  'callout',
+  'image',
+  'code',
+  'taskList',
+  'link',
+  'strikeThrough',
+]
+
+function isValidFeatures(value: unknown): value is MarkdownBenchFeatures {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    featureKeys.every(
+      (key) => typeof (value as Record<string, unknown>)[key] === 'boolean',
+    )
+  )
+}
+
+function isValidState(
+  value: unknown,
+): value is {version: number} & PersistedBenchState {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as {version?: unknown}).version === persistedVersion &&
+    typeof (value as {markdown?: unknown}).markdown === 'string' &&
+    typeof (value as {codeSource?: unknown}).codeSource === 'string' &&
+    ((value as {htmlInlineMode?: unknown}).htmlInlineMode === 'skip' ||
+      (value as {htmlInlineMode?: unknown}).htmlInlineMode === 'text') &&
+    isValidFeatures((value as {features?: unknown}).features)
+  )
+}
+
+export function loadPersistedState(): PersistedBenchState | null {
+  try {
+    const raw = localStorage.getItem(storageKey)
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw)
+    return isValidState(parsed)
+      ? {
+          markdown: parsed.markdown,
+          codeSource: parsed.codeSource,
+          features: parsed.features,
+          htmlInlineMode: parsed.htmlInlineMode,
+        }
+      : null
+  } catch {
+    return null
+  }
+}
+
+export function savePersistedState(state: PersistedBenchState): void {
+  try {
+    localStorage.setItem(
+      storageKey,
+      JSON.stringify({version: persistedVersion, ...state}),
+    )
+  } catch {
+    // localStorage can be unavailable (private browsing, quota) - the bench
+    // still works for the session, it just won't survive a reload.
+  }
+}

--- a/apps/playground/src/markdown-bench/schema.ts
+++ b/apps/playground/src/markdown-bench/schema.ts
@@ -1,0 +1,197 @@
+import {
+  defineSchema,
+  type BlockObjectDefinition,
+  type SchemaDefinition,
+} from '@portabletext/editor'
+
+export type MarkdownBenchFeatures = {
+  table: boolean
+  callout: boolean
+  image: boolean
+  code: boolean
+  taskList: boolean
+  link: boolean
+  strikeThrough: boolean
+}
+
+export const defaultFeatures: MarkdownBenchFeatures = {
+  table: true,
+  callout: true,
+  image: true,
+  code: true,
+  taskList: true,
+  link: true,
+  strikeThrough: true,
+}
+
+export const featureLabels: Record<keyof MarkdownBenchFeatures, string> = {
+  table: 'Table',
+  callout: 'Callout',
+  image: 'Image',
+  code: 'Code block',
+  taskList: 'Task list',
+  link: 'Link',
+  strikeThrough: 'Strike-through',
+}
+
+const linkFields = [
+  {name: 'href', type: 'string'},
+  {name: 'title', type: 'string'},
+] as const
+
+/**
+ * Builds the schema definition both the editor and `markdownToPortableText`
+ * compile against. The base (styles, lists, decorators) mirrors
+ * `@portabletext/markdown`'s `default-schema.ts`; the toggles gate the
+ * optional block objects and the `strike-through`/`task`/`link` extras.
+ *
+ * The callout `content` field and the table cell `value` field deviate from
+ * `default-schema.ts`: they nest a restricted `nestedTextBlock` sub-schema
+ * (normal style only) instead of `default-schema.ts`'s untyped array /
+ * bare `{type: 'block'}` reference. The restriction is load-bearing, not
+ * cosmetic drift: `content`/`value` back a `defineContainer` in
+ * `editor-nodes.tsx`, and a container derives its allowed member types from
+ * the field's `of`, so an untyped array would leave the callout with no
+ * sub-schema to create or edit text blocks against.
+ *
+ * `extraBlockObjects` merges in block-object definitions the options pane's
+ * `schemaTypes.blockObjects` contributes, so a snippet whose output uses a
+ * type the toggles don't declare (e.g. `list`, `blockquote`) still compiles
+ * for both the editor and the converter.
+ */
+export function buildSchemaDefinition(
+  features: MarkdownBenchFeatures,
+  extraBlockObjects: ReadonlyArray<BlockObjectDefinition> = [],
+): SchemaDefinition {
+  const decorators = [
+    {name: 'strong'},
+    {name: 'em'},
+    {name: 'code'},
+    ...(features.strikeThrough ? [{name: 'strike-through'}] : []),
+  ] as const
+  const annotations = features.link
+    ? ([{name: 'link', fields: linkFields}] as const)
+    : ([] as const)
+  const nestedTextBlock = {
+    type: 'block',
+    styles: [{name: 'normal'}],
+    decorators,
+    annotations,
+  } as const
+
+  return defineSchema({
+    block: {
+      fields: [{name: 'checked', type: 'boolean'}],
+    },
+    styles: [
+      {name: 'normal'},
+      {name: 'h1'},
+      {name: 'h2'},
+      {name: 'h3'},
+      {name: 'h4'},
+      {name: 'h5'},
+      {name: 'h6'},
+      {name: 'blockquote'},
+    ],
+    lists: [
+      {name: 'number'},
+      {name: 'bullet'},
+      ...(features.taskList ? [{name: 'task'}] : []),
+    ],
+    decorators,
+    annotations,
+    blockObjects: [
+      {name: 'horizontal-rule'},
+      {name: 'html', fields: [{name: 'html', type: 'string'}]},
+      ...(features.callout
+        ? [
+            {
+              name: 'callout',
+              fields: [
+                {name: 'tone', type: 'string'},
+                {name: 'content', type: 'array', of: [nestedTextBlock]},
+              ],
+            } as const,
+          ]
+        : []),
+      ...(features.code
+        ? [
+            {
+              name: 'code',
+              fields: [
+                {name: 'language', type: 'string'},
+                {name: 'code', type: 'string'},
+              ],
+            } as const,
+          ]
+        : []),
+      ...(features.image
+        ? [
+            {
+              name: 'image',
+              fields: [
+                {name: 'src', type: 'string'},
+                {name: 'alt', type: 'string'},
+                {name: 'title', type: 'string'},
+              ],
+            } as const,
+          ]
+        : []),
+      ...(features.table
+        ? [
+            {
+              name: 'table',
+              fields: [
+                {name: 'headerRows', type: 'number'},
+                {name: 'alignment', type: 'array'},
+                {
+                  name: 'rows',
+                  type: 'array',
+                  of: [
+                    {
+                      type: 'object',
+                      name: 'row',
+                      fields: [
+                        {
+                          name: 'cells',
+                          type: 'array',
+                          of: [
+                            {
+                              type: 'object',
+                              name: 'cell',
+                              fields: [
+                                {
+                                  name: 'value',
+                                  type: 'array',
+                                  of: features.image
+                                    ? [nestedTextBlock, {type: 'image'}]
+                                    : [nestedTextBlock],
+                                },
+                              ],
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            } as const,
+          ]
+        : []),
+      ...extraBlockObjects,
+    ],
+    inlineObjects: features.image
+      ? [
+          {
+            name: 'image',
+            fields: [
+              {name: 'src', type: 'string'},
+              {name: 'alt', type: 'string'},
+              {name: 'title', type: 'string'},
+            ],
+          },
+        ]
+      : [],
+  })
+}

--- a/apps/playground/src/markdown-bench/seed.md
+++ b/apps/playground/src/markdown-bench/seed.md
@@ -1,0 +1,45 @@
+# Markdown bench
+
+## Formatting
+
+This paragraph has **bold**, _italic_, ~~strikethrough~~, and `inline code`.
+It also links to the [Portable Text spec](https://github.com/portabletext/portabletext).
+
+### Lists
+
+- A bullet item
+  - A nested bullet item
+- Another bullet item
+
+1. A numbered item
+2. Another numbered item
+
+- [ ] An unchecked task
+- [x] A checked task
+
+### Table
+
+| Feature  | Status |
+| -------- | ------ |
+| Tables   | Done   |
+| Callouts | Done   |
+
+> [!NOTE]
+> This is a callout, rendered from a GFM alert.
+
+```js
+function greet(name) {
+  return `Hello, ${name}!`
+}
+```
+
+![A placeholder image](https://portabletext.org/favicon.svg)
+
+### Inline extras
+
+This paragraph has inline HTML, H<sup>2</sup>O, and an inline image ![a small icon](https://portabletext.org/favicon.svg) sitting mid-sentence.
+
+---
+
+A paragraph with a hard break.\
+The second line lands after it.

--- a/apps/playground/src/markdown-bench/snippets.ts
+++ b/apps/playground/src/markdown-bench/snippets.ts
@@ -1,0 +1,112 @@
+type OptionsSnippet = {
+  id: string
+  label: string
+  source: string
+}
+
+const noneSource = `// Contract: return {toPortableText?, toMarkdown?, schemaTypes?}.
+// - toPortableText merges into markdownToPortableText's options: schema,
+//   html, and matchers for marks/block/listItem/types. The schema and html
+//   keys are owned by the toggles above: overriding them here changes
+//   parsing only, the editor pane will not follow.
+// - toMarkdown merges into portableTextToMarkdown's options: renderers for
+//   types/marks/block.
+// - schemaTypes.blockObjects adds block-object definitions to the schema
+//   both panes compile, for output that uses types the toggle-derived
+//   schema doesn't declare.
+// Either half may be omitted. Whatever a key sets here wins over the
+// schema-toggle-derived options for that key.
+({})
+`
+
+const playgroundTypesSource = `// Adapters for the main playground's block shapes, which differ from this
+// bench's default schema. Modeled on previews/markdown-options.ts.
+({
+  toMarkdown: {
+    types: {
+      // The main playground's code block holds one text block per line
+      // ({lines: [...]}) rather than a single \`code\` string. Reads span
+      // text directly so the output doesn't pick up list/style formatting
+      // from the inner blocks.
+      'code-block': ({value}) => {
+        const lines = value.lines ?? []
+        const code = lines
+          .map((line) =>
+            (line.children ?? [])
+              .map((child) => (child._type === 'span' ? (child.text ?? '') : ''))
+              .join(''),
+          )
+          .join('\\n')
+        const fence = '\`\`\`'
+        return fence + '\\n' + code + '\\n' + fence
+      },
+      // The main playground names its horizontal rule object \`break\`; this
+      // bench's default schema names it \`horizontal-rule\` (already handled
+      // by the default renderer without an override).
+      break: helpers.DefaultHorizontalRuleRenderer,
+    },
+  },
+})
+`
+
+const structuralContainersSource = `// Diverts lists and blockquotes into structural block-objects (explicit
+// \`items\`/\`content\` arrays) instead of the default flat
+// listItem/level/style fields. See the \`types.list\`/\`types.blockquote\`
+// options in markdown-to-portable-text.ts. The toggle-derived schema
+// doesn't declare \`list\`/\`blockquote\` block objects, so this snippet
+// ships them via schemaTypes, merged into both panes' schema.
+({
+  toPortableText: {
+    types: {
+      list: ({context, value}) => ({
+        _key: context.keyGenerator(),
+        _type: 'list',
+        kind: value.kind,
+        items: value.items,
+      }),
+      blockquote: ({context, value}) => ({
+        _key: context.keyGenerator(),
+        _type: 'blockquote',
+        content: value.content,
+      }),
+    },
+  },
+  toMarkdown: {
+    types: {
+      list: helpers.DefaultListRenderer,
+      blockquote: helpers.DefaultBlockquoteObjectRenderer,
+    },
+  },
+  schemaTypes: {
+    blockObjects: [
+      {
+        name: 'list',
+        fields: [
+          {name: 'kind', type: 'string'},
+          {name: 'items', type: 'array'},
+        ],
+      },
+      {
+        name: 'blockquote',
+        fields: [{name: 'content', type: 'array'}],
+      },
+    ],
+  },
+})
+`
+
+export const optionsSnippets: Array<OptionsSnippet> = [
+  {id: 'none', label: 'None', source: noneSource},
+  {
+    id: 'playground-types',
+    label: 'Playground types',
+    source: playgroundTypesSource,
+  },
+  {
+    id: 'structural-containers',
+    label: 'Structural containers',
+    source: structuralContainersSource,
+  },
+]
+
+export const defaultSnippet = optionsSnippets[0]!

--- a/apps/playground/src/page-nav.tsx
+++ b/apps/playground/src/page-nav.tsx
@@ -23,6 +23,15 @@ export function PageNav() {
       >
         Minimal
       </Link>
+      <Link
+        to="/markdown"
+        inactiveProps={{className: button({variant: 'ghost', size: 'sm'})}}
+        activeProps={{
+          className: button({variant: 'ghost', size: 'sm', isSelected: true}),
+        }}
+      >
+        Markdown
+      </Link>
     </nav>
   )
 }

--- a/apps/playground/src/routeTree.gen.ts
+++ b/apps/playground/src/routeTree.gen.ts
@@ -10,11 +10,17 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as MarkdownRouteImport } from './routes/markdown'
 import { Route as MinimalRouteImport } from './routes/minimal'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MarkdownRoute = MarkdownRouteImport.update({
+  id: '/markdown',
+  path: '/markdown',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MinimalRoute = MinimalRouteImport.update({
@@ -25,27 +31,31 @@ const MinimalRoute = MinimalRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/markdown': typeof MarkdownRoute
   '/minimal': typeof MinimalRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/markdown': typeof MarkdownRoute
   '/minimal': typeof MinimalRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/markdown': typeof MarkdownRoute
   '/minimal': typeof MinimalRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/minimal'
+  fullPaths: '/' | '/markdown' | '/minimal'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/minimal'
-  id: '__root__' | '/' | '/minimal'
+  to: '/' | '/markdown' | '/minimal'
+  id: '__root__' | '/' | '/markdown' | '/minimal'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  MarkdownRoute: typeof MarkdownRoute
   MinimalRoute: typeof MinimalRoute
 }
 
@@ -56,6 +66,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/markdown': {
+      id: '/markdown'
+      path: '/markdown'
+      fullPath: '/markdown'
+      preLoaderRoute: typeof MarkdownRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/minimal': {
@@ -70,6 +87,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  MarkdownRoute: MarkdownRoute,
   MinimalRoute: MinimalRoute,
 }
 export const routeTree = rootRouteImport

--- a/apps/playground/src/routes/markdown.tsx
+++ b/apps/playground/src/routes/markdown.tsx
@@ -1,0 +1,6 @@
+import {createFileRoute} from '@tanstack/react-router'
+import {MarkdownBench} from '../markdown-bench/markdown-bench'
+
+export const Route = createFileRoute('/markdown')({
+  component: MarkdownBench,
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,6 +352,9 @@ importers:
       '@portabletext/react':
         specifier: catalog:tooling
         version: 8.0.1(react@19.2.8)
+      '@portabletext/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
       '@portabletext/toolbar':
         specifier: workspace:*
         version: link:../../packages/toolbar


### PR DESCRIPTION
## What

A `/markdown` playground page for stress testing markdown ↔ Portable Text conversion: a rich editor and an editable markdown pane stay in sync in both directions, so you edit Portable Text with markdown as the vessel.

Stacked on #3241 (it needs the playground's routing); the diff to review here is `playground-routing..playground-markdown-page`.

The sync is focus-gated: the pane you type in is the only writer. That is a consequence of the conversion contract, since every markdown parse regenerates block keys, so a continuous pipe would fight the editor's selection. Editor mutations are debounced, so the markdown pane's `onFocus` first serializes the engine's live value before taking over; without that handoff, keystrokes typed just before a pane switch would flush into a closed gate and get reverted.

The page is a test bench, not just a demo:

- Schema toggles (table, callout, image, code, task list, link, strike-through) and an `html.inline` switch. Markdown is the durable state: a toggle remounts the editor with the markdown re-parsed through the new schema, so the documented degradations (tables flatten, fences become text) happen live in front of you.
- An options pane where matcher/renderer functions are real code, compiled with `new Function` on Apply, with the `@portabletext/markdown` exports and schema helpers in scope. Three starter snippets load into it. A `schemaTypes` contribution merges into the schema used by both the editor and the converter, so the two panes never run different schemas.
- Broken code or a failing re-parse rejects the change and keeps the last good conversion in both panes, with the error in a strip.
- Markdown, code, and toggles persist to localStorage; Reset restores the seeded showcase document.

## Verification

The conversion logic is pinned by a Node harness run against this branch: seed parsing, toggle degradations, serialize→parse→serialize fixpoint, all three snippets evaluating and converting both ways, `schemaTypes` merging, broken source throwing. The DOM layer (focus handoff, remount behavior, persistence) is verified by source tracing only; this sandbox cannot launch a browser, so give the preview deploy's `/markdown` a real click-through, especially typing in the editor and immediately clicking into the markdown pane.
