### PR TITLE
fix: delete auto-resolve validation repairs in favor of engine normalization

### DIFF
--- a/.changeset/delete-auto-resolve-repairs.md
+++ b/.changeset/delete-auto-resolve-repairs.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: delete auto-resolve validation repairs in favor of engine normalization
+
+The editor's own normalization now repairs every mechanically fixable defect in a synced value (missing or empty `children`, missing block and child `_key`s), and the repair patches take the engine's shapes: a keyless block gets a minimal `set` on its `_key` field instead of a whole-block `set`, and an empty text block gets its placeholder span as an `insert` before `children[0]`.
+
+Two deltas ride along. Orphaned `markDefs` are no longer pruned when a value enters the editor; they are pruned when a local edit next touches the block, emitted as a `set` of the filtered `markDefs` array. And `InvalidValueResolution.autoResolve` is deprecated and never set: defects the editor can fix itself no longer produce a resolution, so the invalid-value flow only fires for defects that genuinely need a human.

--- a/packages/editor/src/editor/create-editor.ts
+++ b/packages/editor/src/editor/create-editor.ts
@@ -275,13 +275,6 @@ function createActors(config: {
         case 'value changed':
           config.relay.send(event)
           break
-        case 'patch':
-          config.editorActor.send({
-            ...event,
-            type: 'internal.patch',
-            value: config.editorEngine.snapshot.context.value,
-          })
-          break
 
         default:
           config.editorActor.send(event)

--- a/packages/editor/src/editor/sync-machine.test.ts
+++ b/packages/editor/src/editor/sync-machine.test.ts
@@ -7,9 +7,12 @@ import {updateSelectionPlugin} from '../engine-plugins/engine-plugin.update-sele
 import type {ApplyContextFrame} from '../engine/core/apply-context'
 import {subscribeToOperations} from '../engine/core/operation-channel'
 import {createEditor} from '../engine/create-editor'
+import {withoutNormalizing} from '../engine/editor/without-normalizing'
+import type {Node} from '../engine/interfaces/node'
+import type {EngineOperation} from '../engine/interfaces/operation'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import {editorMachine} from './editor-machine'
-import {syncMachine} from './sync-machine'
+import {syncMachine, updateBlock} from './sync-machine'
 
 function createTestEngine(keyGenerator: () => string) {
   const schema = compileSchema(defineSchema({}))
@@ -88,5 +91,207 @@ describe('sync machine', () => {
     })
 
     expect(remoteFrames).toEqual([{kind: 'remote', source: 'update-value'}])
+  })
+
+  test(`${updateBlock.name} replaces children wholesale instead of building a \`{_key: undefined}\` path when a child lacks a usable key`, () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, schema} = createTestEngine(keyGenerator)
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+
+    const oldEngineBlock: Node = {
+      _type: 'block',
+      _key: blockKey,
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+        {
+          _type: 'span',
+          _key: undefined as unknown as string,
+          text: 'bar',
+          marks: [],
+        },
+      ],
+    }
+    editor.snapshot.context.value = [oldEngineBlock]
+    // Mirrors how `syncBlock` always invokes `updateBlock`: inside a remote
+    // frame (suppresses cosmetic normalization unrelated to this fallback)
+    // and with normalization deferred until the wrapper exits.
+    editor.applyContext = [{kind: 'remote', source: 'update-value'}]
+
+    const appliedOps: Array<EngineOperation> = []
+    const originalApply = editor.apply.bind(editor)
+    editor.apply = (op: EngineOperation) => {
+      appliedOps.push(op)
+      return originalApply(op)
+    }
+
+    withoutNormalizing(editor, () => {
+      updateBlock({
+        context: {
+          keyGenerator,
+          previousValue: undefined,
+          schema,
+        },
+        editorEngine: editor,
+        oldEngineBlock,
+        block: {
+          _type: 'block',
+          _key: blockKey,
+          style: 'normal',
+          markDefs: [],
+          children: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', text: 'baz', marks: []},
+          ],
+        },
+        index: 0,
+      })
+    })
+
+    expect(appliedOps).toEqual([
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'markDefs'],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'children'],
+        value: [
+          {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+          {_type: 'span', text: 'baz', marks: []},
+        ],
+        inverse: {
+          type: 'set',
+          path: [{_key: blockKey}, 'children'],
+          value: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', text: 'bar', marks: []},
+          ],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'children', 1, '_key'],
+        value: 'k2',
+        inverse: {
+          type: 'unset',
+          path: [{_key: blockKey}, 'children', 1, '_key'],
+        },
+      },
+    ])
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+          {_type: 'span', _key: 'k2', text: 'baz', marks: []},
+        ],
+      },
+    ])
+  })
+
+  test(`${updateBlock.name} replaces children wholesale, and normalization inserts the placeholder span, when the incoming block has no children`, () => {
+    const keyGenerator = createTestKeyGenerator()
+    const {editor, schema} = createTestEngine(keyGenerator)
+    const blockKey = keyGenerator()
+    const fooKey = keyGenerator()
+    const barKey = keyGenerator()
+
+    const oldEngineBlock: Node = {
+      _type: 'block',
+      _key: blockKey,
+      style: 'normal',
+      markDefs: [],
+      children: [
+        {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+        {_type: 'span', _key: barKey, text: 'bar', marks: []},
+      ],
+    }
+    editor.snapshot.context.value = [oldEngineBlock]
+    // Mirrors how `syncBlock` always invokes `updateBlock`: inside a remote
+    // frame (suppresses cosmetic normalization unrelated to this fallback)
+    // and with normalization deferred until the wrapper exits.
+    editor.applyContext = [{kind: 'remote', source: 'update-value'}]
+
+    const appliedOps: Array<EngineOperation> = []
+    const originalApply = editor.apply.bind(editor)
+    editor.apply = (op: EngineOperation) => {
+      appliedOps.push(op)
+      return originalApply(op)
+    }
+
+    withoutNormalizing(editor, () => {
+      updateBlock({
+        context: {
+          keyGenerator,
+          previousValue: undefined,
+          schema,
+        },
+        editorEngine: editor,
+        oldEngineBlock,
+        block: {
+          _type: 'block',
+          _key: blockKey,
+          style: 'normal',
+          markDefs: [],
+          children: [],
+        },
+        index: 0,
+      })
+    })
+
+    expect(appliedOps).toEqual([
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'markDefs'],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [{_key: blockKey}, 'markDefs'],
+          value: [],
+        },
+      },
+      {
+        type: 'set',
+        path: [{_key: blockKey}, 'children'],
+        value: [],
+        inverse: {
+          type: 'set',
+          path: [{_key: blockKey}, 'children'],
+          value: [
+            {_type: 'span', _key: fooKey, text: 'foo', marks: []},
+            {_type: 'span', _key: barKey, text: 'bar', marks: []},
+          ],
+        },
+      },
+      {
+        type: 'insert',
+        path: [{_key: blockKey}, 'children', 0],
+        node: {_type: 'span', _key: 'k3', text: '', marks: []},
+        position: 'before',
+      },
+    ])
+
+    expect(editor.snapshot.context.value).toEqual([
+      {
+        _type: 'block',
+        _key: blockKey,
+        style: 'normal',
+        markDefs: [],
+        children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+      },
+    ])
   })
 })

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -1,4 +1,3 @@
-import {applyAll, type Patch} from '@portabletext/patches'
 import {isSpan, isTextBlock, type PortableTextBlock} from '@portabletext/schema'
 import type {ActorRefFrom} from 'xstate'
 import {
@@ -43,10 +42,6 @@ import {isKeyedSegment} from '../utils/util.is-keyed-segment'
 import type {EditorSchema} from './editor-schema'
 
 type SyncValueEvent =
-  | {
-      type: 'patch'
-      patch: Patch
-    }
   | {
       type: 'invalid value'
       resolution: InvalidValueResolution | null
@@ -127,11 +122,7 @@ export const syncMachine = setup({
         }
       | SyncValueEvent,
     emitted: {} as
-      | PickFromUnion<
-          SyncValueEvent,
-          'type',
-          'invalid value' | 'patch' | 'value changed'
-        >
+      | PickFromUnion<SyncValueEvent, 'type', 'invalid value' | 'value changed'>
       | {type: 'done syncing value'}
       | {type: 'syncing value'},
   },
@@ -382,9 +373,6 @@ export const syncMachine = setup({
         'update value': {
           guard: 'is new value',
           actions: ['assign pending value'],
-        },
-        'patch': {
-          actions: [emit(({event}) => event)],
         },
         'invalid value': {
           actions: [emit(({event}) => event)],
@@ -704,29 +692,15 @@ function syncBlock({
   const oldBlock = editorEngine.snapshot.context.value.at(index)
 
   if (!oldEngineBlock || !oldBlock) {
-    const validation = validateValue(
-      [block],
-      context.schema,
-      context.keyGenerator,
-    )
+    const validation = validateValue([block], context.schema)
 
     debug.syncValue(
       'Validating and inserting new block in the end of the value',
       block,
     )
 
-    reportAutoResolution({
-      validation,
-      context,
-      sendBack,
-      value,
-      index,
-      key: block._key,
-    })
-
-    if (validation.valid || validation.resolution?.autoResolve) {
-      const repairedBlock = applyAutoResolution(validation, [block], block)
-      const engineBlock = toEngineBlock(repairedBlock, {
+    if (validation.valid) {
+      const engineBlock = toEngineBlock(block, {
         schemaTypes: context.schema,
       })
 
@@ -778,31 +752,11 @@ function syncBlock({
     }
   }
   const validationValue = [blockToValidate]
-  const validation = validateValue(
-    validationValue,
-    context.schema,
-    context.keyGenerator,
-  )
+  const validation = validateValue(validationValue, context.schema)
 
-  // Resolve validations that can be resolved automatically, without involving the user (but only if the value was changed)
-  reportAutoResolution({
-    validation,
-    context,
-    sendBack,
-    value,
-    index,
-    key: blockToValidate._key,
-  })
-
-  if (validation.valid || validation.resolution?.autoResolve) {
-    const repairedBlock = applyAutoResolution(
-      validation,
-      validationValue,
-      block,
-    )
-
+  if (validation.valid) {
     if (oldBlock._key === block._key && oldBlock._type === block._type) {
-      debug.syncValue('Updating block', oldBlock, repairedBlock)
+      debug.syncValue('Updating block', oldBlock, block)
 
       withRemoteChanges(editorEngine, remoteSource, () => {
         withoutNormalizing(editorEngine, () => {
@@ -811,14 +765,14 @@ function syncBlock({
               context,
               editorEngine,
               oldEngineBlock,
-              block: repairedBlock,
+              block,
               index,
             })
           })
         })
       })
     } else {
-      debug.syncValue('Replacing block', oldBlock, repairedBlock)
+      debug.syncValue('Replacing block', oldBlock, block)
 
       withRemoteChanges(editorEngine, remoteSource, () => {
         withoutNormalizing(editorEngine, () => {
@@ -826,7 +780,7 @@ function syncBlock({
             replaceBlock({
               context,
               editorEngine,
-              block: repairedBlock,
+              block,
               index,
             })
           })
@@ -850,85 +804,6 @@ function syncBlock({
       blockValid: false,
     }
   }
-}
-
-/**
- * Reports an auto-resolved repair's patches to the host, addressed by the
- * block's real position in the incoming value: `validateValue` validates
- * one block at a time, so a resolution's block-level numeric path
- * segments (minting a missing block `_key`) are always local `0` and need
- * rebasing; resolutions already anchored on the block's own `_key` are
- * position-independent and pass through unchanged.
- */
-function reportAutoResolution({
-  validation,
-  context,
-  sendBack,
-  value,
-  index,
-  key,
-}: {
-  validation: ReturnType<typeof validateValue>
-  context: {previousValue: Array<PortableTextBlock> | undefined}
-  sendBack: (event: SyncValueEvent) => void
-  value: Array<PortableTextBlock>
-  index: number
-  key: string | undefined
-}) {
-  if (
-    !validation.valid &&
-    validation.resolution?.autoResolve &&
-    validation.resolution?.patches.length > 0
-  ) {
-    if (context.previousValue !== value) {
-      // A re-run against an unchanged value would mint and report a fresh
-      // repair for the same defect.
-      // `validateValue` ran on `[block]`, so its description can only name
-      // index 0; point the message at the block's real position.
-      const description = validation.resolution.description.replace(
-        'index 0',
-        `index ${index}`,
-      )
-      const location =
-        key !== undefined
-          ? `block with _key '${key}'`
-          : `block at index ${index}`
-      console.warn(
-        `${validation.resolution.action} for ${location}. ${description}`,
-      )
-      validation.resolution.patches.forEach((patch) => {
-        sendBack({
-          type: 'patch',
-          patch: {...rebaseBlockPatchPath(patch, index), origin: 'local'},
-        })
-      })
-    }
-  }
-}
-
-function rebaseBlockPatchPath(patch: Patch, index: number): Patch {
-  const [head, ...rest] = patch.path
-  return typeof head === 'number' ? {...patch, path: [index, ...rest]} : patch
-}
-
-/**
- * `validateValue` auto-resolutions must reach the engine as state, not
- * only the document as patches. Applying them only outbound forks the
- * repair: the document receives the resolution (e.g. a minted child
- * `_key`) while the engine holds the un-repaired shape its addressing
- * model cannot represent, and normalization then mints a different key
- * for the same node. The resolution patches were built from
- * `validationValue` itself, so they always apply; the fallback only
- * covers the impossible empty result.
- */
-function applyAutoResolution(
-  validation: ReturnType<typeof validateValue>,
-  validationValue: Array<PortableTextBlock>,
-  block: PortableTextBlock,
-): PortableTextBlock {
-  return !validation.valid && validation.resolution?.autoResolve
-    ? (applyAll(validationValue, validation.resolution.patches).at(0) ?? block)
-    : block
 }
 
 function replaceBlock({
@@ -991,7 +866,7 @@ function replaceBlock({
   }
 }
 
-function updateBlock({
+export function updateBlock({
   context,
   editorEngine,
   oldEngineBlock,
@@ -1060,8 +935,19 @@ function updateBlock({
       oldKeySet.size === oldKeys.length &&
       oldKeys.some((key, i) => key !== newKeys[i]) &&
       newKeys.every((key) => oldKeySet.has(key))
+    // Keyed reconciliation below builds `{_key: child._key}` path segments
+    // from `engineBlock.children`; a keyless child would produce
+    // `{_key: undefined}`, so route those cases through the wholesale set.
+    const hasKeylessChild = engineBlock.children.some(
+      (child) => typeof child._key !== 'string' || child._key === '',
+    )
 
-    if (isPureReorder || (newKeys.length > 0 && !hasSharedKeys)) {
+    if (
+      isPureReorder ||
+      (newKeys.length > 0 && !hasSharedKeys) ||
+      engineBlock.children.length === 0 ||
+      hasKeylessChild
+    ) {
       debug.syncValue('Replacing children via set')
       applyNodeProperties(editorEngine, {children: engineBlock.children}, [
         {_key: oldEngineBlock._key},

--- a/packages/editor/src/internal-utils/validateValue.ts
+++ b/packages/editor/src/internal-utils/validateValue.ts
@@ -1,11 +1,11 @@
-import {insert, set, setIfMissing, unset} from '@portabletext/patches'
+import {set, unset} from '@portabletext/patches'
 import {
-  isSpan,
   isTextBlock,
   type PortableTextBlock,
   type PortableTextTextBlock,
 } from '@portabletext/schema'
 import type {EditorSchema} from '../editor/editor-schema'
+import {hasUsableKey, nodeSegment} from '../paths/node-segment'
 import {getRootAcceptedTypes} from '../schema/get-root-accepted-types'
 import type {InvalidValueResolution} from '../types/editor'
 
@@ -15,10 +15,29 @@ interface Validation {
   value: PortableTextBlock[] | undefined
 }
 
+/**
+ * A keyless block has no identifier that survives across the single-block
+ * slices the sync machine validates one at a time, so patches anchor on it
+ * by its position within `value` instead.
+ */
+function describeBlockLocation(blk: PortableTextBlock, index: number): string {
+  return hasUsableKey(blk._key)
+    ? `with _key '${blk._key}'`
+    : `at index '${index}'`
+}
+
+function describeEnclosingBlockLocation(
+  blk: PortableTextBlock,
+  index: number,
+): string {
+  return hasUsableKey(blk._key)
+    ? `with key '${blk._key}'`
+    : `at index '${index}'`
+}
+
 export function validateValue(
   value: PortableTextBlock[] | undefined,
   types: EditorSchema,
-  keyGenerator: () => string,
 ): Validation {
   let resolution: InvalidValueResolution | null = null
   let valid = true
@@ -71,24 +90,6 @@ export function validateValue(
         }
         return true
       }
-      // Test that every block has a _key prop
-      if (!blk._key || typeof blk._key !== 'string') {
-        resolution = {
-          autoResolve: true,
-          patches: [set({...blk, _key: keyGenerator()}, [index])],
-          description: `Block at index ${index} is missing required _key.`,
-          action: 'Set the block with a random _key value',
-          item: blk,
-
-          i18n: {
-            description:
-              'inputs.portable-text.invalid-value.missing-key.description',
-            action: 'inputs.portable-text.invalid-value.missing-key.action',
-            values: {index},
-          },
-        }
-        return true
-      }
       // Test that every block has valid _type
       if (!blk._type || !validBlockTypes.has(blk._type)) {
         // Special case where block type is set to default 'block', but the block type is named something else according to the schema.
@@ -96,9 +97,11 @@ export function validateValue(
           const currentBlockTypeName = types.block.name
           resolution = {
             patches: [
-              set({...blk, _type: currentBlockTypeName}, [{_key: blk._key}]),
+              set({...blk, _type: currentBlockTypeName}, [
+                nodeSegment(blk, index),
+              ]),
             ],
-            description: `Block with _key '${blk._key}' has invalid type name '${blk._type}'. According to the schema, the block type name is '${currentBlockTypeName}'`,
+            description: `Block ${describeBlockLocation(blk, index)} has invalid type name '${blk._type}'. According to the schema, the block type name is '${currentBlockTypeName}'`,
             action: `Use type '${currentBlockTypeName}'`,
             item: blk,
 
@@ -120,9 +123,9 @@ export function validateValue(
         ) {
           resolution = {
             patches: [
-              set({...blk, _type: types.block.name}, [{_key: blk._key}]),
+              set({...blk, _type: types.block.name}, [nodeSegment(blk, index)]),
             ],
-            description: `Block with _key '${blk._key}' is missing a type name. According to the schema, the block type name is '${types.block.name}'`,
+            description: `Block ${describeBlockLocation(blk, index)} is missing a type name. According to the schema, the block type name is '${types.block.name}'`,
             action: `Use type '${types.block.name}'`,
             item: blk,
 
@@ -139,8 +142,8 @@ export function validateValue(
 
         if (!blk._type) {
           resolution = {
-            patches: [unset([{_key: blk._key}])],
-            description: `Block with _key '${blk._key}' is missing an _type property`,
+            patches: [unset([nodeSegment(blk, index)])],
+            description: `Block ${describeBlockLocation(blk, index)} is missing an _type property`,
             action: 'Remove the block',
             item: blk,
 
@@ -155,8 +158,8 @@ export function validateValue(
         }
 
         resolution = {
-          patches: [unset([{_key: blk._key}])],
-          description: `Block with _key '${blk._key}' has invalid _type '${blk._type}'`,
+          patches: [unset([nodeSegment(blk, index)])],
+          description: `Block ${describeBlockLocation(blk, index)} has invalid _type '${blk._type}'`,
           action: 'Remove the block',
           item: blk,
 
@@ -176,8 +179,8 @@ export function validateValue(
         // Test that it has a valid children property (array)
         if (textBlock.children && !Array.isArray(textBlock.children)) {
           resolution = {
-            patches: [set({children: []}, [{_key: textBlock._key}])],
-            description: `Text block with _key '${textBlock._key}' has a invalid required property 'children'.`,
+            patches: [set({children: []}, [nodeSegment(textBlock, index)])],
+            description: `Text block ${describeBlockLocation(textBlock, index)} has a invalid required property 'children'.`,
             action: 'Reset the children property',
             item: textBlock,
 
@@ -191,200 +194,115 @@ export function validateValue(
           }
           return true
         }
-        // Test that children is set and lengthy
-        if (
-          textBlock.children === undefined ||
-          (Array.isArray(textBlock.children) && textBlock.children.length === 0)
-        ) {
-          const newSpan = {
-            _type: types.span.name,
-            _key: keyGenerator(),
-            text: '',
-            marks: [],
-          }
-          resolution = {
-            autoResolve: true,
-            patches: [
-              setIfMissing([], [{_key: blk._key}, 'children']),
-              insert([newSpan], 'after', [{_key: blk._key}, 'children', 0]),
-            ],
-            description: `Children for text block with _key '${blk._key}' is empty.`,
-            action: 'Insert an empty text',
-            item: blk,
+        // A missing or empty `children` array is mechanically fixable
+        // (the engine inserts an empty span); only run child-level checks
+        // when there's something to check.
+        if (Array.isArray(textBlock.children)) {
+          // Test every child
+          if (
+            textBlock.children.some((child, cIndex: number) => {
+              if (typeof child !== 'object' || child === null) {
+                resolution = {
+                  patches: [
+                    unset([nodeSegment(blk, index), 'children', cIndex]),
+                  ],
+                  description: `Child at index '${cIndex}' in block ${describeEnclosingBlockLocation(blk, index)} is not an object.`,
+                  action: 'Remove the item',
+                  item: blk,
 
-            i18n: {
-              description:
-                'inputs.portable-text.invalid-value.empty-children.description',
-              action:
-                'inputs.portable-text.invalid-value.empty-children.action',
-              values: {key: blk._key},
-            },
-          }
-          return true
-        }
-
-        const allUsedMarks = [
-          ...new Set(
-            textBlock.children
-              .filter((child) => isSpan({schema: types}, child))
-              .flatMap((cld) => cld.marks || []),
-          ),
-        ]
-
-        // Test that all markDefs are in use (remove orphaned markDefs)
-        if (Array.isArray(blk.markDefs) && blk.markDefs.length > 0) {
-          const unusedMarkDefs: string[] = [
-            ...new Set(
-              blk.markDefs
-                .map((def) => def._key)
-                .filter((key) => !allUsedMarks.includes(key)),
-            ),
-          ]
-          if (unusedMarkDefs.length > 0) {
-            resolution = {
-              autoResolve: true,
-              patches: unusedMarkDefs.map((markDefKey) =>
-                unset([{_key: blk._key}, 'markDefs', {_key: markDefKey}]),
-              ),
-              description: `Block contains orphaned data (unused mark definitions): ${unusedMarkDefs.join(
-                ', ',
-              )}.`,
-              action: 'Remove unused mark definition item',
-              item: blk,
-              i18n: {
-                description:
-                  'inputs.portable-text.invalid-value.orphaned-mark-defs.description',
-                action:
-                  'inputs.portable-text.invalid-value.orphaned-mark-defs.action',
-                values: {
-                  key: blk._key,
-                  unusedMarkDefs: unusedMarkDefs.map((m) => m.toString()),
-                },
-              },
-            }
-            return true
-          }
-        }
-
-        // Test every child
-        if (
-          textBlock.children.some((child, cIndex: number) => {
-            if (typeof child !== 'object' || child === null) {
-              resolution = {
-                patches: [unset([{_key: blk._key}, 'children', cIndex])],
-                description: `Child at index '${cIndex}' in block with key '${blk._key}' is not an object.`,
-                action: 'Remove the item',
-                item: blk,
-
-                i18n: {
-                  description:
-                    'inputs.portable-text.invalid-value.non-object-child.description',
-                  action:
-                    'inputs.portable-text.invalid-value.non-object-child.action',
-                  values: {key: blk._key, index: cIndex},
-                },
-              }
-              return true
-            }
-
-            if (!child._key || typeof child._key !== 'string') {
-              const newKey = keyGenerator()
-              resolution = {
-                autoResolve: true,
-                patches: [
-                  set(newKey, [{_key: blk._key}, 'children', cIndex, '_key']),
-                ],
-                description: `Child at index ${cIndex} is missing required _key in block with _key ${blk._key}.`,
-                action: 'Set a new random _key on the object',
-                item: blk,
-
-                i18n: {
-                  description:
-                    'inputs.portable-text.invalid-value.missing-child-key.description',
-                  action:
-                    'inputs.portable-text.invalid-value.missing-child-key.action',
-                  values: {key: blk._key, index: cIndex},
-                },
-              }
-              return true
-            }
-
-            // Verify that children have valid types
-            if (!child._type) {
-              resolution = {
-                patches: [
-                  unset([{_key: blk._key}, 'children', {_key: child._key}]),
-                ],
-                description: `Child with _key '${child._key}' in block with key '${blk._key}' is missing '_type' property.`,
-                action: 'Remove the object',
-                item: blk,
-
-                i18n: {
-                  description:
-                    'inputs.portable-text.invalid-value.missing-child-type.description',
-                  action:
-                    'inputs.portable-text.invalid-value.missing-child-type.action',
-                  values: {key: blk._key, childKey: child._key},
-                },
-              }
-              return true
-            }
-
-            if (!validChildTypes.includes(child._type)) {
-              resolution = {
-                patches: [
-                  unset([{_key: blk._key}, 'children', {_key: child._key}]),
-                ],
-                description: `Child with _key '${child._key}' in block with key '${blk._key}' has invalid '_type' property (${child._type}).`,
-                action: 'Remove the object',
-                item: blk,
-
-                i18n: {
-                  description:
-                    'inputs.portable-text.invalid-value.disallowed-child-type.description',
-                  action:
-                    'inputs.portable-text.invalid-value.disallowed-child-type.action',
-                  values: {
-                    key: blk._key,
-                    childKey: child._key,
-                    childType: child._type,
+                  i18n: {
+                    description:
+                      'inputs.portable-text.invalid-value.non-object-child.description',
+                    action:
+                      'inputs.portable-text.invalid-value.non-object-child.action',
+                    values: {key: blk._key, index: cIndex},
                   },
-                },
+                }
+                return true
               }
-              return true
-            }
 
-            // Verify that spans have .text property that is a string
-            if (
-              child._type === types.span.name &&
-              typeof child.text !== 'string'
-            ) {
-              resolution = {
-                patches: [
-                  set({...child, text: ''}, [
-                    {_key: blk._key},
-                    'children',
-                    {_key: child._key},
-                  ]),
-                ],
-                description: `Child with _key '${child._key}' in block with key '${blk._key}' has missing or invalid text property!`,
-                action: `Write an empty text property to the object`,
-                item: blk,
+              // A missing child `_key` is mechanically fixable; fall back to
+              // the child's index so a later check on the same child doesn't
+              // build a `{_key: undefined}` path segment.
+              const childRef = nodeSegment(child, cIndex)
 
-                i18n: {
-                  description:
-                    'inputs.portable-text.invalid-value.invalid-span-text.description',
-                  action:
-                    'inputs.portable-text.invalid-value.invalid-span-text.action',
-                  values: {key: blk._key, childKey: child._key},
-                },
+              // Verify that children have valid types
+              if (!child._type) {
+                resolution = {
+                  patches: [
+                    unset([nodeSegment(blk, index), 'children', childRef]),
+                  ],
+                  description: `Child with _key '${child._key}' in block ${describeEnclosingBlockLocation(blk, index)} is missing '_type' property.`,
+                  action: 'Remove the object',
+                  item: blk,
+
+                  i18n: {
+                    description:
+                      'inputs.portable-text.invalid-value.missing-child-type.description',
+                    action:
+                      'inputs.portable-text.invalid-value.missing-child-type.action',
+                    values: {key: blk._key, childKey: child._key},
+                  },
+                }
+                return true
               }
-              return true
-            }
-            return false
-          })
-        ) {
-          valid = false
+
+              if (!validChildTypes.includes(child._type)) {
+                resolution = {
+                  patches: [
+                    unset([nodeSegment(blk, index), 'children', childRef]),
+                  ],
+                  description: `Child with _key '${child._key}' in block ${describeEnclosingBlockLocation(blk, index)} has invalid '_type' property (${child._type}).`,
+                  action: 'Remove the object',
+                  item: blk,
+
+                  i18n: {
+                    description:
+                      'inputs.portable-text.invalid-value.disallowed-child-type.description',
+                    action:
+                      'inputs.portable-text.invalid-value.disallowed-child-type.action',
+                    values: {
+                      key: blk._key,
+                      childKey: child._key,
+                      childType: child._type,
+                    },
+                  },
+                }
+                return true
+              }
+
+              // Verify that spans have .text property that is a string
+              if (
+                child._type === types.span.name &&
+                typeof child.text !== 'string'
+              ) {
+                resolution = {
+                  patches: [
+                    set({...child, text: ''}, [
+                      nodeSegment(blk, index),
+                      'children',
+                      childRef,
+                    ]),
+                  ],
+                  description: `Child with _key '${child._key}' in block ${describeEnclosingBlockLocation(blk, index)} has missing or invalid text property!`,
+                  action: `Write an empty text property to the object`,
+                  item: blk,
+
+                  i18n: {
+                    description:
+                      'inputs.portable-text.invalid-value.invalid-span-text.description',
+                    action:
+                      'inputs.portable-text.invalid-value.invalid-span-text.action',
+                    values: {key: blk._key, childKey: child._key},
+                  },
+                }
+                return true
+              }
+              return false
+            })
+          ) {
+            valid = false
+          }
         }
       }
       return false

--- a/packages/editor/src/types/editor.ts
+++ b/packages/editor/src/types/editor.ts
@@ -108,6 +108,10 @@ export type EditorSelection = {
  * The editor has invalid data in the value that can be resolved by the user
  * @public */
 export type InvalidValueResolution = {
+  /**
+   * @deprecated Never set. Mechanically fixable defects are repaired by the
+   * editor itself and no longer produce a resolution.
+   */
   autoResolve?: boolean
   patches: Patch[]
   description: string

--- a/packages/editor/tests/event.operation.test.tsx
+++ b/packages/editor/tests/event.operation.test.tsx
@@ -110,9 +110,9 @@ describe('event.operation', () => {
     const {editor} = await createTestEditor()
     const operations = collectOperations(editor)
 
-    // A text block with no children is auto-resolved by `validateValue` at
-    // sync ingress: the placeholder span is part of the inserted node
-    // itself, not a separate normalization fix operation.
+    // Validation passes a text block with no children through untouched;
+    // engine normalization repairs it afterward, inserting the placeholder
+    // span as its own operation, adjacent to the block's own insert.
     editor.send({type: 'update value', value: [emptyBlock('b1')]})
 
     await vi.waitFor(() => {
@@ -125,10 +125,13 @@ describe('event.operation', () => {
           type: 'insert',
           path: [0],
           position: 'before',
-          node: {
-            ...emptyBlock('b1'),
-            children: [{_type: 'span', _key: 'k2', text: '', marks: []}],
-          },
+          node: emptyBlock('b1'),
+        },
+        {
+          type: 'insert',
+          path: [{_key: 'b1'}, 'children', 0],
+          position: 'before',
+          node: {_type: 'span', _key: 'k2', text: '', marks: []},
         },
       ])
     })

--- a/packages/editor/tests/event.update-value.test.tsx
+++ b/packages/editor/tests/event.update-value.test.tsx
@@ -2200,16 +2200,10 @@ describe('event.update value: auto-resolved invalid blocks', () => {
       ],
     })
 
-    const unsetPatch = {
-      type: 'unset',
-      path: [{_key: 'b0'}, 'markDefs', {_key: 'm1'}],
-      origin: 'local',
-    }
-
-    // The auto-resolution is emitted as a patch AND applied to the block
-    // the engine receives: the def is gone on both sides.
+    // Intake passes the raw block through untouched: the orphan survives
+    // until something else marks the block dirty.
     await vi.waitFor(() => {
-      expect(patches).toEqual([unsetPatch])
+      expect(patches).toEqual([])
       expect(editor.getSnapshot().context.value).toEqual([
         {
           _key: 'b0',
@@ -2217,14 +2211,15 @@ describe('event.update value: auto-resolved invalid blocks', () => {
           children: [
             {_key: 's0', _type: 'span', text: 'hello changed', marks: []},
           ],
-          markDefs: [],
+          markDefs: [{_key: 'm1', _type: 'link', href: 'https://example.com'}],
           style: 'normal',
         },
       ])
     })
 
-    // The repair already published on `update value`; a further local
-    // edit's patches append to the same stream.
+    // The first local edit marks the block dirty: normalization removes
+    // the orphan in the same pass, emitting its wholesale `set` alongside
+    // the edit's own patch.
     editor.send({
       type: 'select',
       at: {
@@ -2236,7 +2231,6 @@ describe('event.update value: auto-resolved invalid blocks', () => {
 
     await vi.waitFor(() => {
       expect(patches).toEqual([
-        unsetPatch,
         {
           type: 'diffMatchPatch',
           path: [{_key: 'b0'}, 'children', {_key: 's0'}, 'text'],
@@ -2244,6 +2238,23 @@ describe('event.update value: auto-resolved invalid blocks', () => {
             makePatches(makeDiff('hello changed', 'hello changed!')),
           ),
           origin: 'local',
+        },
+        {
+          type: 'set',
+          path: [{_key: 'b0'}, 'markDefs'],
+          value: [],
+          origin: 'local',
+        },
+      ])
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _key: 'b0',
+          _type: 'block',
+          children: [
+            {_key: 's0', _type: 'span', text: 'hello changed!', marks: []},
+          ],
+          markDefs: [],
+          style: 'normal',
         },
       ])
     })
@@ -2581,8 +2592,8 @@ describe('event.update value: auto-resolved invalid blocks', () => {
     }
     const repairPatch = {
       type: 'set',
-      path: [1],
-      value: repairedBlock1,
+      path: [1, '_key'],
+      value: 'k2',
       origin: 'local',
     }
 

--- a/packages/editor/tests/placeholder-block.test.tsx
+++ b/packages/editor/tests/placeholder-block.test.tsx
@@ -291,7 +291,7 @@ describe(createPlaceholderBlock.name, () => {
         {
           type: 'insert',
           path: [{_key: 'k0'}, 'children', 0],
-          position: 'after',
+          position: 'before',
           items: [{_key: 'k2', _type: 'span', marks: [], text: ''}],
         },
       ]

--- a/packages/editor/tests/pteWarningsSelfSolving.test.tsx
+++ b/packages/editor/tests/pteWarningsSelfSolving.test.tsx
@@ -335,7 +335,7 @@ describe('when PTE would display warnings, instead it self solves', () => {
 
     const onChange = vi.fn()
 
-    await createTestEditor({
+    const {editor} = await createTestEditor({
       children: (
         <>
           <EventListenerPlugin on={onChange} />
@@ -364,6 +364,55 @@ describe('when PTE would display warnings, instead it self solves', () => {
                 _key: 'def',
                 _type: 'span',
                 text: 'Hello',
+                marks: [],
+              },
+            ],
+            // Focusing does not dirty the block, so the orphaned markDef
+            // stays exactly as the document has it until a local edit.
+            markDefs: [
+              {
+                _key: 'ghi',
+                _type: 'link',
+                href: 'https://sanity.io',
+              },
+            ],
+            style: 'normal',
+          },
+        ])
+      }
+    })
+
+    // Provoke the self-solving: a local edit touching the block removes
+    // the orphan as part of that edit.
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'abc'}, 'children', {_key: 'def'}], offset: 5},
+        focus: {path: [{_key: 'abc'}, 'children', {_key: 'def'}], offset: 5},
+      },
+    })
+    editor.send({type: 'insert.text', text: '!'})
+
+    await vi.waitFor(() => {
+      expect(onChange).toHaveBeenCalledWith({
+        type: 'patch',
+        patch: {
+          type: 'set',
+          path: [{_key: 'abc'}, 'markDefs'],
+          value: [],
+          origin: 'local',
+        },
+      })
+      if (editorRef.current) {
+        expect(PortableTextEditor.getValue(editorRef.current)).toEqual([
+          {
+            _key: 'abc',
+            _type: 'block',
+            children: [
+              {
+                _key: 'def',
+                _type: 'span',
+                text: 'Hello!',
                 marks: [],
               },
             ],

--- a/packages/editor/tests/validation.test.tsx
+++ b/packages/editor/tests/validation.test.tsx
@@ -1,8 +1,13 @@
-import {defineSchema} from '@portabletext/schema'
+import {
+  compileSchema,
+  defineSchema,
+  type PortableTextBlock,
+} from '@portabletext/schema'
 import {createTestKeyGenerator, toTextspec} from '@portabletext/test'
 import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import type {EditorEmittedEvent} from '../src/editor/relay'
+import {validateValue} from '../src/internal-utils/validateValue'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {createTestEditor} from '../src/test/vitest'
 
@@ -768,5 +773,39 @@ describe('Value validation', () => {
         style: 'normal',
       },
     ])
+  })
+
+  test('A keyless block anchors its resolution patch on its index, not a `{_key: undefined}` segment that would match the first keyless block', () => {
+    const schema = compileSchema(defineSchema({}))
+    const firstKeylessBlock = {
+      _type: 'block',
+      children: [{_type: 'span', text: 'foo', marks: []}],
+    } as unknown as PortableTextBlock
+    const secondKeylessBlock = {
+      _type: 'not-a-real-type',
+      children: [{_type: 'span', text: 'bar', marks: []}],
+    } as unknown as PortableTextBlock
+
+    const validation = validateValue(
+      [firstKeylessBlock, secondKeylessBlock],
+      schema,
+    )
+
+    expect(validation).toEqual({
+      valid: false,
+      resolution: {
+        patches: [{type: 'unset', path: [1]}],
+        description: "Block at index '1' has invalid _type 'not-a-real-type'",
+        action: 'Remove the block',
+        item: secondKeylessBlock,
+        i18n: {
+          description:
+            'inputs.portable-text.invalid-value.disallowed-type.description',
+          action: 'inputs.portable-text.invalid-value.disallowed-type.action',
+          values: {key: undefined, typeName: 'not-a-real-type'},
+        },
+      },
+      value: [firstKeylessBlock, secondKeylessBlock],
+    })
   })
 })


### PR DESCRIPTION
With #3246, the editor emits its structural repair patches the moment a value settles. That left `validateValue`'s `autoResolve` resolutions as a second repairer running ahead of the engine: four rules (missing block `_key`, missing or empty `children`, orphaned `markDefs`, missing child `_key`) repaired blocks before ingestion and reported through the sync actor's out-of-band `patch` channel, with their own patch shapes and their own addressing quirks.

This PR deletes them and makes engine normalization the sole repairer. Validation passes mechanically fixable shapes through untouched; the engine repairs them on intake and its patches emit in engine shapes: a keyless block gets a minimal `set` on its minted `_key` (previously a whole-block `set`), an empty text block gets its placeholder span as an `insert` before `children[0]`. The sync actor's `patch` channel and its reporting machinery go with the rules. The invalid-value flow is untouched for defects that genuinely need a human, and its remaining resolutions now resolve their block anchors through `nodeSegment`, so a keyless block with a non-mechanical defect is addressed by its numeric index instead of a `{_key: undefined}` segment that keyed matching would resolve to the first keyless sibling (pinned red-on-old).

Raw input reaches `updateBlock` for the first time, so it gains a wholesale-set fallback: children arrays with keyless members, or a raw empty `children` replacing populated children, are set wholesale and normalization mints the keys; no `{_key: undefined}` segment is ever applied (pinned by unit tests asserting the full applied-operation streams).

Two deliberate deltas. Orphaned `markDefs` are no longer pruned at intake: the engine's prune is local-only by design, so orphans go when a local edit next dirties the block, emitted as a `set` of the filtered array (a read-only editor never prunes them). And sync `insert` operations now carry the raw block, with normalization repairs following as their own operations. `InvalidValueResolution.autoResolve` is deprecated rather than removed, never set.

One caveat: the empty-block placeholder span now travels as `insert ... before children[0]` where the deleted rule used `insert ... after children[0]`; both anchor index 0 of an empty array, and whether Content Lake treats the two anchors identically on an empty array is not verifiable from this repo. Client-side application (`applyAll`) is pinned equivalent.

Stacked on #3246 and merges after it; the base branch is `emit-repair-patches-immediately`.
