### PR TITLE
fix: emit reliable patches after clearing the editor (v7)

### DIFF
--- a/.changeset/echo-sync-not-persistence-v7.md
+++ b/.changeset/echo-sync-not-persistence-v7.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: emit reliable patches after clearing the editor
+
+Deleting all content makes the editor emit an `unset` patch that removes the entire value. Typing again then emitted patches that assumed the value still existed. Applying those patches dropped the typed text, or threw `Cannot apply deep operations on primitive values`.
+
+The editor now first emits patches that create the value again: `setIfMissing`, an `insert` of the block, then the text changes. Deleting all content again emits `unset` again.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -80,6 +80,7 @@ export function createEditorEngine(
   editor.isDeferringMutations = false
   editor.lastSyncedValue = undefined
   editor.isNormalizingNode = false
+  editor.valueUnsetEmitted = false
   editor.isPatching = true
   editor.isPerformingBehaviorOperation = false
   editor.isProcessingRemoteChanges = false

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -47,7 +47,13 @@ export function subscribePatchGeneration({
     const editorWasEmpty =
       previousValue.length === 1 &&
       isEqualToEmptyEditor(initialValue, previousValue, schema) &&
-      !isEqualValues({schema}, editor.lastSyncedValue, previousValue)
+      // After this editor emits `unset([])`, its own stream must
+      // re-materialize the field before targeting it again, no matter what
+      // value sync recorded in between: a mirroring host's stale echo of
+      // the cleared state syncs as a genuine write and would otherwise
+      // pass the placeholder off as persisted content.
+      (editor.valueUnsetEmitted ||
+        !isEqualValues({schema}, editor.lastSyncedValue, previousValue))
 
     const editorIsEmpty =
       editor.snapshot.context.value.length === 1 &&
@@ -104,11 +110,19 @@ export function subscribePatchGeneration({
       ['set', 'unset', 'remove.text'].includes(operation.type)
     ) {
       patches = [...patches, unset([])]
+      editor.valueUnsetEmitted = true
     }
 
     // Prepend patches with setIfMissing if going from empty editor to something involving a patch.
     if (editorWasEmpty && patches.length > 0) {
       patches = [setIfMissing([], []), ...patches]
+      editor.valueUnsetEmitted = false
+      if (isEqualValues({schema}, editor.lastSyncedValue, previousValue)) {
+        // Rebuilding right over the recorded value proves the recording
+        // was a stale echo of the cleared state; keeping it would make the
+        // next became-empty transition skip its `unset([])`.
+        editor.lastSyncedValue = undefined
+      }
     }
 
     // Emit all patches

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -55,6 +55,7 @@ type SyncValueEvent =
   | {
       type: 'done syncing'
       value: Array<PortableTextBlock> | undefined
+      changed: boolean
     }
 
 const syncValueCallback: CallbackLogicFunction<
@@ -162,7 +163,11 @@ export const syncMachine = setup({
     }),
     'record synced value on engine': ({context, event}) => {
       assertEvent(event, 'done syncing')
-      context.editorEngine.lastSyncedValue = event.value
+      if (event.changed) {
+        // A sync that wrote nothing is not a host persistence claim; see
+        // `lastSyncedValue`.
+        context.editorEngine.lastSyncedValue = event.value
+      }
     },
     'emit done syncing value': emit({
       type: 'done syncing value',
@@ -542,7 +547,7 @@ async function updateValue({
 
     doneSyncing = true
 
-    sendBack({type: 'done syncing', value})
+    sendBack({type: 'done syncing', value, changed: isChanged})
 
     return
   }
@@ -563,7 +568,7 @@ async function updateValue({
 
       doneSyncing = true
 
-      sendBack({type: 'done syncing', value})
+      sendBack({type: 'done syncing', value, changed: isChanged})
 
       return
     }
@@ -584,7 +589,7 @@ async function updateValue({
 
   doneSyncing = true
 
-  sendBack({type: 'done syncing', value})
+  sendBack({type: 'done syncing', value, changed: isChanged})
 }
 
 async function* getStreamedBlocks({value}: {value: Array<PortableTextBlock>}) {

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -84,11 +84,23 @@ export interface PortableTextEditorEngine extends DOMEditor {
 
   isDeferringMutations: boolean
   /**
-   * The last host value written in by value sync. A pristine block equal
-   * to it is persisted content, not the local placeholder.
+   * The last host value recorded by a value sync that changed the engine. A
+   * pristine block equal to it is persisted content, not the local
+   * placeholder. Syncs that write nothing are not recorded: hosts mirror
+   * `mutation.value` back as `update value`, and such an echo of the
+   * editor's own state (its placeholder included) is not a claim that the
+   * value is persisted.
    */
   lastSyncedValue: Array<PortableTextBlock> | undefined
   isNormalizingNode: boolean
+  /**
+   * True after patch generation emits a became-empty `unset([])`, until it
+   * emits the field's rebuild (`setIfMissing` plus the block `insert`).
+   * While true, the emitted stream has destroyed the field, so the next
+   * content-producing local edit must re-materialize it even if a synced
+   * value makes the placeholder look persisted.
+   */
+  valueUnsetEmitted: boolean
   isPatching: boolean
   isPerformingBehaviorOperation: boolean
   /**

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5395,6 +5395,289 @@ describe('event.patches', () => {
     })
   })
 
+  test('Scenario: Retyping after clearing the field when the host mirrors values', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // A host following the documented pattern: mirror the mutation's value
+    // back into `update value`. The echo of the editor's own placeholder
+    // must not count as a host persistence claim, or the retype below
+    // stops re-materializing the field it just unset.
+    const mutations: Array<Array<Patch>> = []
+    editor.on('mutation', (event) => {
+      mutations.push(event.patches)
+      editor.send({type: 'update value', value: event.value})
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('fo', 'foo'))),
+        origin: 'local',
+      })
+    })
+
+    // A model-level selection over the whole text plus one Backspace
+    // clears in a single flush on every platform (chord-based word
+    // deletion is OS-dependent).
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    // Waiting on the mutation (not the earlier per-patch relay) orders the
+    // echo before the retype: `editor.on` subscribers run in the emit
+    // turn, so once the clear's mutation is observed, the mirrored
+    // `update value` has already been sent.
+    await vi.waitFor(() => {
+      expect(mutations.at(-1)?.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+    const patchCountAfterClear = patches.length
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterClear)).toEqual([
+        {
+          type: 'setIfMissing',
+          path: [],
+          value: [],
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'b'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('b', 'ba'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('ba', 'bar'))),
+          origin: 'local',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: 'bar', marks: []}],
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Retyping after a character-by-character clear when the host mirrors values', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // Unlike the single-flush clear above, a character-by-character clear
+    // spreads across flushes. The sync machine defers the mirrored echoes
+    // while local mutations are pending, so they coalesce into one no-op
+    // sync of the editor's own cleared state. The editor's own `unset([])`
+    // emission must override whatever that echo recorded: its stream
+    // destroyed the field, so the retype must rebuild it.
+    const mutations: Array<Array<Patch>> = []
+    editor.on('mutation', (event) => {
+      mutations.push(event.patches)
+      editor.send({type: 'update value', value: event.value})
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('fo', 'foo'))),
+        origin: 'local',
+      })
+    })
+
+    await userEvent.keyboard('{Backspace}{Backspace}{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    // The echo settles when the clear's own mutation (ending in the
+    // became-empty `unset([])`) has been observed, so the mirrored
+    // `update value` carrying the cleared state has been sent, and the
+    // engine is back at the placeholder. Only then has the poisoned value
+    // been recorded, which is the state the retype below must survive.
+    await vi.waitFor(() => {
+      expect(mutations.at(-1)?.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+        },
+      ])
+    })
+    const patchCountAfterClear = patches.length
+
+    await userEvent.type(locator, 'bar')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterClear)).toEqual([
+        {
+          type: 'setIfMissing',
+          path: [],
+          value: [],
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'b'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('b', 'ba'))),
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('ba', 'bar'))),
+          origin: 'local',
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: 'bar', marks: []}],
+        },
+      ])
+    })
+
+    // A second clear must unset the field again: the stale echo recorded
+    // during the first clear is spent by the rebuild above and may not
+    // make this transition treat the placeholder as persisted content.
+    const patchCountBeforeSecondClear = patches.length
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountBeforeSecondClear)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('bar', ''))),
+          origin: 'local',
+        },
+        {
+          type: 'unset',
+          path: [],
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
   test('Scenario: Remote `insert` next to a pristine block synced in via `update value`', async () => {
     const {editor} = await createTestEditor({
       keyGenerator: createTestKeyGenerator(),


### PR DESCRIPTION
Clearing a Portable Text field and typing into it again could silently lose the new text, or crash the consumer applying the emitted patches (`Cannot apply deep operations on primitive values`): the retype flush emitted only `diffMatchPatch`es against a field the same patch stream had just `unset([])`. It reproduces with any host that mirrors `mutation.value` back into `update value`, which is the documented wiring.

The editor tells a synced-in pristine block apart from its own local placeholder by remembering the last synced value, and the mirror's echo after a clear recorded the placeholder itself as that evidence. Recording now happens only when a sync actually wrote into the engine, and patch generation tracks its own became-empty `unset([])`: until the rebuild is emitted, the next content-producing edit always re-materializes the field. The same narrow trade as on main rides along: a genuine empty block arriving through `update value` between the editor's own unset and its next keystroke is rebuilt rather than suppressed.

Backport of #3236 to the `editor-v7.x` line, which carries the regression (`46c019cc3`, the pristine-block fix that introduced `lastSyncedValue`, shipped in 7.10.17). Two adaptations: the cherry-pick's only conflicts were adjacency with engine flags this branch has, and the character-by-character scenario's settle precondition waits on the clear's own mutation instead of a remote-origin write, because on this branch the mirrored echoes never land as remote-origin writes in that scenario (a cadence difference; the ported sources are identical to main's apart from remote-frame plumbing). Both scenarios red five-for-five on the unpatched branch and green five-for-five with the fix.
