### PR TITLE
chore: drop `catalogMode: prefer`

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,8 +24,6 @@ catalog:
   react-dom: ^19.2.8
   xstate: ^5.32.5
 
-catalogMode: prefer
-
 catalogs:
   tooling:
     "@portabletext/react": ^8.0.1


### PR DESCRIPTION
The `sharp` 0.35.4 and `astro` 7.2.8 security PRs (#3248, #3249) arrived with every CI job failing at `pnpm install --frozen-lockfile` with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. The cause is `catalogMode: prefer`: under it, `pnpm update` catalog-izes a dependency that is not in the catalog, writing an entry to `pnpm-workspace.yaml`, rewriting the manifest specifier to `catalog:`, and recording the entry in the lockfile's `catalogs` section. Renovate regenerates the lockfile with such a command for in-range security updates and commits only the lockfile, so the lockfile ends up claiming a catalog entry the workspace config does not have.

This PR drops the setting (back to the default `manual`). It only affected `pnpm add`/`pnpm update` write behavior, so resolution and the lockfile are unchanged; the trade-off is that adding a dep that already has a catalog entry no longer writes `catalog:` automatically, which becomes review discipline instead.

Reproduced on `main` with `pnpm update sharp@0.35.4 --lockfile-only`, which produces exactly the three-file write described above; with the setting removed the same command leaves the catalog untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workspace-only pnpm configuration with no application or runtime code changes.
> 
> **Overview**
> Removes **`catalogMode: prefer`** from `pnpm-workspace.yaml`, so pnpm uses the default **`manual`** catalog behavior for `pnpm add` / `pnpm update`.
> 
> That stops lockfile-only updates (e.g. Renovate security bumps) from auto-adding catalog entries and rewriting manifests to `catalog:` when a dependency isn’t already in the catalog—behavior that caused **`ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`** on **`pnpm install --frozen-lockfile`** when only the lockfile was committed.
> 
> **Trade-off:** new or updated deps that match an existing catalog entry won’t get `catalog:` written automatically; reviewers need to align manifests with the catalog by hand. Dependency resolution and the existing lockfile are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea54c0ed807f18e1e6ae2443dff37f7543fa32d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->