### PR TITLE
fix: re-materialize the field before patches emitted while it is unset

### DIFF
--- a/.changeset/root-unset-rematerialization.md
+++ b/.changeset/root-unset-rematerialization.md
@@ -1,0 +1,9 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: re-materialize the field before patches emitted while it is unset
+
+A behavior replacing the whole value in one action set (a root `unset` followed by an `insert`) previously emitted a patch stream that patch-applying stores could not apply: an `insert` into a field the preceding `unset` had removed. Consumers saw `Cannot apply deep operations on primitive values`.
+
+One narrow behavioral fix rides along: clearing the editor through a behavior-raised root `unset` now re-materializes the field on the next edit under a value-mirroring host, the same way clearing it with the keyboard already did.

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -110,18 +110,49 @@ export function subscribePatchGeneration({
       ['set', 'unset', 'remove.text'].includes(operation.type)
     ) {
       patches = [...patches, unset([])]
-      editor.valueUnsetEmitted = true
     }
 
     // Prepend patches with setIfMissing if going from empty editor to something involving a patch.
     if (editorWasEmpty && patches.length > 0) {
       patches = [setIfMissing([], []), ...patches]
-      editor.valueUnsetEmitted = false
       if (isEqualValues({schema}, editor.lastSyncedValue, previousValue)) {
         // Rebuilding right over the recorded value proves the recording
         // was a stale echo of the cleared state; keeping it would make the
         // next became-empty transition skip its `unset([])`.
         editor.lastSyncedValue = undefined
+      }
+    }
+
+    // Prepend patches with setIfMissing when a root `unset` earlier in this
+    // editor's emitted stream destroyed the field: the store cannot apply
+    // patches into a destroyed field until something rebuilds it, and these
+    // patches are neither the destroy nor the rebuild themselves.
+    const [firstPatch] = patches
+    if (
+      previousValue.length === 0 &&
+      editor.valueUnsetEmitted &&
+      firstPatch &&
+      !(
+        (firstPatch.type === 'unset' && firstPatch.path.length === 0) ||
+        ((firstPatch.type === 'setIfMissing' || firstPatch.type === 'set') &&
+          firstPatch.path.length === 0)
+      )
+    ) {
+      patches = [setIfMissing([], []), ...patches]
+    }
+
+    // The stream's own truth about whether the field is currently
+    // destroyed, derived after every prepend/append above has had its say:
+    // a root `unset` destroys it, a root `setIfMissing` or `set` rebuilds
+    // it, and nothing else changes the verdict.
+    for (const patch of patches) {
+      if (patch.type === 'unset' && patch.path.length === 0) {
+        editor.valueUnsetEmitted = true
+      } else if (
+        (patch.type === 'setIfMissing' || patch.type === 'set') &&
+        patch.path.length === 0
+      ) {
+        editor.valueUnsetEmitted = false
       }
     }
 

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -90,11 +90,12 @@ export interface PortableTextEditorEngine extends DOMEditor {
    */
   lastSyncedValue: Array<PortableTextBlock> | undefined
   /**
-   * True after patch generation emits a became-empty `unset([])`, until it
-   * emits the field's rebuild (`setIfMissing` plus the block `insert`).
-   * While true, the emitted stream has destroyed the field, so the next
-   * content-producing local edit must re-materialize it even if a synced
-   * value makes the placeholder look persisted.
+   * True while this editor's own emitted patch stream has destroyed the
+   * field (a root `unset([])` went out) and not yet re-materialized it (a
+   * root `setIfMissing` or `set` went out since). While true, patch
+   * generation rebuilds the field before targeting it again and treats a
+   * placeholder equal to `lastSyncedValue` as unpersisted rather than as
+   * proof the field survived.
    */
   valueUnsetEmitted: boolean
   isPatching: boolean

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -12,6 +12,9 @@ import {makeDiff, makePatches, stringifyPatches} from '@sanity/diff-match-patch'
 import {describe, expect, test, vi} from 'vitest'
 import {userEvent} from 'vitest/browser'
 import {defineSchema, type EditorEmittedEvent} from '../src'
+import {raise} from '../src/behaviors/behavior.types.action'
+import {defineBehavior} from '../src/behaviors/behavior.types.behavior'
+import {BehaviorPlugin} from '../src/plugins/plugin.behavior'
 import {EventListenerPlugin} from '../src/plugins/plugin.event-listener'
 import {NodePlugin} from '../src/plugins/plugin.node'
 import {defineContainer} from '../src/renderers/renderer.types'
@@ -5674,6 +5677,367 @@ describe('event.patches', () => {
         },
       ])
     })
+  })
+
+  test('Scenario: a behavior raising root `unset` then `insert.block` in one action set emits an applicable patch stream', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: keyGenerator(),
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: keyGenerator(), text: 'foo', marks: []},
+        ],
+      },
+    ]
+    const replacementBlock: PortableTextBlock = {
+      _type: 'block',
+      _key: keyGenerator(),
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: keyGenerator(), text: 'bar', marks: []}],
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue,
+      children: (
+        <>
+          <BehaviorPlugin
+            behaviors={[
+              defineBehavior({
+                on: 'custom.replace all',
+                actions: [
+                  () => [
+                    raise({type: 'unset', at: []}),
+                    raise({
+                      type: 'insert.block',
+                      block: replacementBlock,
+                      placement: 'auto',
+                    }),
+                  ],
+                ],
+              }),
+            ]}
+          />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                patches.push(event.patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({type: 'custom.replace all'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([replacementBlock])
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {type: 'unset', path: [], origin: 'local'},
+        {type: 'setIfMissing', path: [], value: [], origin: 'local'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [replacementBlock],
+          origin: 'local',
+        },
+      ])
+    })
+
+    expect(applyAll(initialValue, patches)).toEqual(
+      editor.getSnapshot().context.value,
+    )
+  })
+
+  test('Scenario: a behavior raising root `unset` twice then `insert.block` in one action set emits an applicable patch stream', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: keyGenerator(),
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: keyGenerator(), text: 'foo', marks: []},
+        ],
+      },
+    ]
+    const replacementBlock: PortableTextBlock = {
+      _type: 'block',
+      _key: keyGenerator(),
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: keyGenerator(), text: 'bar', marks: []}],
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue,
+      children: (
+        <>
+          <BehaviorPlugin
+            behaviors={[
+              defineBehavior({
+                on: 'custom.replace all',
+                actions: [
+                  () => [
+                    raise({type: 'unset', at: []}),
+                    raise({type: 'unset', at: []}),
+                    raise({
+                      type: 'insert.block',
+                      block: replacementBlock,
+                      placement: 'auto',
+                    }),
+                  ],
+                ],
+              }),
+            ]}
+          />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                patches.push(event.patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({type: 'custom.replace all'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([replacementBlock])
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {type: 'unset', path: [], origin: 'local'},
+        {type: 'unset', path: [], origin: 'local'},
+        {type: 'setIfMissing', path: [], value: [], origin: 'local'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [replacementBlock],
+          origin: 'local',
+        },
+      ])
+    })
+
+    expect(applyAll(initialValue, patches)).toEqual(
+      editor.getSnapshot().context.value,
+    )
+  })
+
+  test('Scenario: a behavior raising root `unset` then `insert.block` while the editor is an empty placeholder emits an applicable patch stream', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      children: (
+        <>
+          <BehaviorPlugin
+            behaviors={[
+              defineBehavior({
+                on: 'custom.replace all',
+                actions: [
+                  () => {
+                    const replacementBlock: PortableTextBlock = {
+                      _type: 'block',
+                      _key: keyGenerator(),
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {
+                          _type: 'span',
+                          _key: keyGenerator(),
+                          text: 'bar',
+                          marks: [],
+                        },
+                      ],
+                    }
+                    return [
+                      raise({type: 'unset', at: []}),
+                      raise({
+                        type: 'insert.block',
+                        block: replacementBlock,
+                        placement: 'auto',
+                      }),
+                    ]
+                  },
+                ],
+              }),
+            ]}
+          />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                patches.push(event.patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({type: 'custom.replace all'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+        },
+      ])
+    })
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {type: 'setIfMissing', path: [], value: [], origin: 'local'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k0',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {type: 'unset', path: [], origin: 'local'},
+        {type: 'setIfMissing', path: [], value: [], origin: 'local'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k2',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k3', text: 'bar', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+      ])
+    })
+
+    expect(applyAll([] as Array<PortableTextBlock>, patches)).toEqual(
+      editor.getSnapshot().context.value,
+    )
+  })
+
+  test('Scenario: `history.redo` replays a behavior-raised root `unset` then `insert.block` as an applicable patch stream', async () => {
+    const patches: Array<Patch> = []
+    const keyGenerator = createTestKeyGenerator()
+    const initialValue: Array<PortableTextBlock> = [
+      {
+        _type: 'block',
+        _key: keyGenerator(),
+        style: 'normal',
+        markDefs: [],
+        children: [
+          {_type: 'span', _key: keyGenerator(), text: 'foo', marks: []},
+        ],
+      },
+    ]
+    const replacementBlock: PortableTextBlock = {
+      _type: 'block',
+      _key: keyGenerator(),
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: keyGenerator(), text: 'bar', marks: []}],
+    }
+
+    const {editor, locator} = await createTestEditor({
+      keyGenerator,
+      schemaDefinition: defineSchema({}),
+      initialValue,
+      children: (
+        <>
+          <BehaviorPlugin
+            behaviors={[
+              defineBehavior({
+                on: 'custom.replace all',
+                actions: [
+                  () => [
+                    raise({type: 'unset', at: []}),
+                    raise({
+                      type: 'insert.block',
+                      block: replacementBlock,
+                      placement: 'auto',
+                    }),
+                  ],
+                ],
+              }),
+            ]}
+          />
+          <EventListenerPlugin
+            on={(event) => {
+              if (event.type === 'patch') {
+                patches.push(event.patch)
+              }
+            }}
+          />
+        </>
+      ),
+    })
+
+    await userEvent.click(locator)
+    editor.send({type: 'custom.replace all'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([replacementBlock])
+    })
+
+    editor.send({type: 'history.undo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual(initialValue)
+    })
+
+    const patchCountBeforeRedo = patches.length
+
+    editor.send({type: 'history.redo'})
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([replacementBlock])
+    })
+
+    const redoPatches = patches.slice(patchCountBeforeRedo)
+
+    expect(applyAll(initialValue, redoPatches)).toEqual(
+      editor.getSnapshot().context.value,
+    )
   })
 
   test('Scenario: Remote `insert` next to a pristine block synced in via `update value`', async () => {


### PR DESCRIPTION
A behavior that replaces the whole value in one action set (raise a root `unset`, then `insert.block`) emitted a patch stream no patch-applying store could apply: the `insert` targeted a field the preceding `unset([])` had just removed, and applying it throws `Cannot apply deep operations on primitive values`. The editor itself ended in the intended state; only the emitted stream was broken.

The became-empty bookkeeping (`valueUnsetEmitted`) was written from two ad-hoc sites, both keyed to the length-1 placeholder transition. A grouped action set takes the engine through a genuine zero-block state that shape never matches, so the `unset([])` went out without arming the flag and the `insert` went out naked. The flag is now derived from the emitted stream itself: after an event's patches are composed, one walk arms it on a root `unset` and disarms it on a root `setIfMissing`/`set`, and patches emitted while the field is destroyed get `setIfMissing([], [])` prepended. Deriving instead of hand-writing also fixes the orders the ad-hoc writes got wrong, each pinned by its own scenario: a double root unset keeps the flag armed between the unsets, and a replace-all raised from the empty placeholder ends armed even though its event began with the placeholder rebuild. A redo-replay scenario covers the history path.

One narrow fix rides along, disclosed in the changeset: behavior-raised root unsets now arm the same re-materialization guard that keyboard clearing already had, so a retype after such a clear rebuilds the field under a value-mirroring host. Emitted patches are unchanged for every path that does not pass through a destroyed field.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core patch emission and empty-field bookkeeping; incorrect logic could alter patch streams for clear/replace flows, though scope is narrow and heavily tested.
> 
> **Overview**
> Fixes **broken patch streams** when behaviors replace the whole document in one action set (root `unset` then `insert.block`). Stores could not apply the emitted `insert` after `unset([])`, causing *Cannot apply deep operations on primitive values*; the editor state was correct, only the outbound patches were wrong.
> 
> **Patch generation** now tracks whether the root field is “destroyed” via `valueUnsetEmitted`, derived by scanning each batch of emitted patches (root `unset` arms it; root `setIfMissing`/`set` disarms it) instead of toggling the flag at two placeholder-transition sites. When the stream is still unset and the next patches are not themselves destroy/rebuild, it **prepends `setIfMissing([], [])`** so downstream inserts apply cleanly. Double root unsets, replace-all from an empty placeholder, and **history redo** are covered by new tests.
> 
> A related fix: clearing via a **behavior-raised root `unset`** now matches keyboard clear—**retyping under a value-mirroring host** re-materializes the field before content patches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5b02ae819513e1294b59cdcc058b8dcbd99bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->