### PR TITLE
docs: ban "delta" and "rides along" in artifact prose across the writing skills

### DIFF
--- a/.agents/skills/changesets/SKILL.md
+++ b/.agents/skills/changesets/SKILL.md
@@ -32,12 +32,13 @@ description: How to write changesets in the Portable Text Editor monorepo. Use w
 - **API changesets enumerate the exact exported names** and show a fenced usage example. Include a resolution-order list when the API has ordering semantics (see the `defineX` render-prop-types and `'*'` catch-all entries in `editor/CHANGELOG.md`).
 - Call out the upgrade action explicitly when the change shifts something consumers iterate, switch over, or type against: "Code that iterates the map will see the new serialized-path keys", "exhaustive switches over `event.type` gain a case".
 - Perf fixes state the numbers.
-- Behavioral deltas that ride along are named explicitly ("One narrow behavioral fix rides along: ...").
+- Secondary behavioral changes shipping in the same release are named explicitly ("One additional change: ...").
+- Banned vocabulary in changeset prose (and any artifact prose): "delta" (write "change") and "rides along"/"ride along" (write "One additional change:" or "Also changed:").
 - Small self-explanatory changes can be **subject-only**.
 
 ## Exemplars (real, from the repo history)
 
-### patch: perf fix with numbers + a rides-along delta
+### patch: perf fix with numbers + a named secondary behavioral change
 
 ```md
 ---
@@ -51,7 +52,10 @@ Backspacing through empty blocks, and any other edit that removes the node the s
 One narrow behavioral fix rides along: when the removed node was addressed by a numeric path, the fallback previously moved the selection to the document's first span; it now moves it to the actual nearest span.
 ```
 
-Why it's good: observable symptom first ("backspacing ... no longer slows down"), numbers with context, and the semantic delta explicitly fenced off.
+Why it's good: observable symptom first ("backspacing ... no longer slows down"), numbers with context, and the secondary behavioral change explicitly fenced
+off. One phrase in it is retired vocabulary: this exemplar predates the ban on
+"rides along", so imitate its structure (the secondary change named, fenced,
+last), not that phrase; write "One additional change: ...".
 
 ### minor: new API with enumerated name + example
 

--- a/.agents/skills/commits/SKILL.md
+++ b/.agents/skills/commits/SKILL.md
@@ -29,7 +29,7 @@ Dense technical prose, wrapped at ~72 columns, structured as:
 
 1. **Old mechanism and why it was wrong**, with the precise failure sequence, name the functions, the inputs, and what the wrong output was.
 2. **The new mechanism.**
-3. **Explicitly scoped behavioral deltas**: "Net behavior unchanged", "Emitted patches only change in the narrow case of...", "One narrow behavioral fix rides along: ...".
+3. **Explicitly scoped behavioral changes** (never the words "delta" or "rides along"): "Net behavior unchanged", "Emitted patches only change in the narrow case of...", "One additional change: ...".
 
 Trivial commits get **no body**. One logical change per commit: tests pinning a contract get their own `test:` commit; refactors are split from fixes.
 
@@ -62,7 +62,7 @@ paths with trailing primitive fields, and a round-trip assertion.
 
 Why it's good: names the function and its contract, gives a concrete input, states the downstream blast radius, then the fix as an invariant ("feeding `entry.path` back...").
 
-### fix with a precise failure sequence + scoped delta (`46593d537`)
+### fix with a precise failure sequence + scoped behavioral change (`46593d537`)
 
 ```
 fix: write a `text`-named field on an inline object during value sync

--- a/.agents/skills/pr-descriptions/SKILL.md
+++ b/.agents/skills/pr-descriptions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-descriptions
-description: How to write pull request descriptions for the Portable Text Editor monorepo. Use whenever opening or editing a PR here. Covers the changeset-led body (the changeset's prose opens the description), the narrative shape for what follows, honesty about semantic deltas, and length that scales with the diff's blast radius, with real merged exemplars.
+description: How to write pull request descriptions for the Portable Text Editor monorepo. Use whenever opening or editing a PR here. Covers the changeset-led body (the changeset's prose opens the description), the narrative shape for what follows, honesty about behavioral changes, and length that scales with the diff's blast radius, with real merged exemplars.
 ---
 
 # Writing PTE PR descriptions
@@ -44,7 +44,7 @@ description: How to write pull request descriptions for the Portable Text Editor
   skill), and it is what the reviewer actually reads; a body that buries it
   under paragraphs gets skipped whole. After it, the body adds only what
   changesets ban: a concrete example of the failure, one sentence naming
-  the fix mechanism, any semantic delta or honest caveat. When the
+  the fix mechanism, any behavioral change or honest caveat. When the
   changeset alone carries the change, it is the whole body. This mirrors
   the changeset's _prose_; body sentences _about_ the changeset ("a
   changeset rides along") remain banned.
@@ -76,7 +76,7 @@ description: How to write pull request descriptions for the Portable Text Editor
 
 ## Honesty
 
-- Volunteer semantic deltas: a behavioral change nobody would catch in
+- Volunteer behavioral changes: one nobody would catch in
   review gets its own sentence, even a narrow one.
 - Say what is _not_ covered: an untested path, a case deliberately left out
   of scope.
@@ -140,7 +140,7 @@ Why it's canonical: opens with the lived symptom, diagnoses with the actual
 growth mechanism, states the fix as an insight about the platform
 (`Schema.compile` canonical instances), the careful-abouts each pair a
 decision with the test guarding it, numbers have before/after + methodology,
-and it **volunteers a semantic delta nobody would have caught in review**.
+and it **volunteers a behavioral change nobody would have caught in review**.
 
 ## Exemplar: feature PR with headings (#2772, merged)
 
@@ -172,6 +172,8 @@ the full text):
 - Claiming coverage the tests didn't actually run; say what was and wasn't
   exercised.
 - Self-assessments that restate the diff; generated-by footers.
+- The words "delta" (write "change") and "rides along"/"ride along" (write
+  "One additional change:") anywhere in artifact prose.
 - The investigation narrative leaking into the body: how the bug was found
   belongs wherever the work is tracked; the body describes the change.
 - Appending paragraphs as the PR evolves instead of rewriting the body.

--- a/.agents/skills/reviewing-prs/SKILL.md
+++ b/.agents/skills/reviewing-prs/SKILL.md
@@ -25,7 +25,7 @@ Read the skill, then audit the artifact against it:
   `fixup!` discipline once in review.
 - **Changesets** → `changesets`: present iff the change is user-facing;
   first line mirrors the commit subject verbatim; consumer-observable
-  prose; rides-along deltas named explicitly.
+  prose; secondary behavioral changes named explicitly.
 - **Test files** → `writing-tests`: canonical suite placement; every
   integration test is its own `Scenario:`; deterministic keys; full-value
   `toEqual`; no sleeps; no summarizer indirection; comments held to the
@@ -34,7 +34,7 @@ Read the skill, then audit the artifact against it:
   why-only; nothing diff-relative; if the commit body already tells it,
   the comment is a duplicate and goes.
 - **PR body** → `pr-descriptions`: draft state, narrative shape, no
-  internal context, semantic deltas volunteered, body sized to the diff.
+  internal context, behavioral changes volunteered, body sized to the diff.
 
 ## Verify claims empirically
 
@@ -47,7 +47,7 @@ evidence or produce it:
 - Run the gates the diff touches: `check:types`, `check:lint`,
   `check:format`, `check:knip`, and the affected package's test suites.
 - Spot-check "full value" assertions for smuggled partial matchers.
-- A named behavioral delta must have a test proving the _new_ behavior;
+- A named behavioral change must have a test proving the _new_ behavior;
   an unnamed one found in the diff is a blocker, not a nit.
 
 ## Report


### PR DESCRIPTION
Both are banned vocabulary in every artifact we write (PR bodies, changesets, commit messages, tickets): "delta" becomes "change", and a secondary change is introduced as "One additional change:", not "rides along". The writing skills used both as instruction vocabulary, which is how they kept leaking into artifacts. This PR rewords the four skills, adds the bans explicitly, and annotates the one verbatim historical exemplar that predates them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to `.agents/skills`; no product code, APIs, or runtime behavior.
> 
> **Overview**
> Standardizes **artifact prose vocabulary** in the changesets, commits, pr-descriptions, and reviewing-prs agent skills so banned terms stop leaking from instructions into PRs, changesets, and commit bodies.
> 
> **"Delta"** and **"rides along"** are now explicitly forbidden; writers use **"change"** and phrases like **"One additional change:"** instead. Headings and guidance that said "semantic delta" or "rides-along delta" are reworded to **behavioral change** / **secondary behavioral change**, including review checklists (e.g. named behavioral changes must have tests).
> 
> The historical changeset exemplar is **left verbatim** but annotated: copy its structure (secondary change named last), not the retired **"rides along"** wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf38ce567876965aca9f4634bf672296cd2f4349. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->