### PR TITLE
feat: gate the default markdown renderers on the schema in `portableTextToMarkdown`

### DIFF
--- a/.changeset/gate-default-renderers-on-schema.md
+++ b/.changeset/gate-default-renderers-on-schema.md
@@ -1,0 +1,33 @@
+---
+'@portabletext/markdown': minor
+---
+
+feat: gate the default markdown renderers on the schema in `portableTextToMarkdown`
+
+`portableTextToMarkdown` now accepts an optional `schema`. When set, each built-in type renderer (`callout`, `code`, `horizontal-rule`, `html`, `image`, `table`) runs only when the schema declares that type at the matching position (`blockObjects` for a block, `inlineObjects` for an inline object); an undeclared type falls back to `unknownType`, whose default output is a `json:object` fence (or tagged code span, inline) that reparses back to the same value under the same schema. Renderers you pass in `types` are never gated. The gate checks the type name only, so declare each type with its fields: `markdownToPortableText` cannot rebuild a value from a fieldless declaration. Omit `schema` and every default renderer stays active, as before.
+
+
+```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+import {portableTextToMarkdown} from '@portabletext/markdown'
+
+const schema = compileSchema(
+  defineSchema({
+    blockObjects: [
+      {
+        name: 'code',
+        fields: [
+          {name: 'code', type: 'string'},
+          {name: 'language', type: 'string'},
+        ],
+      },
+    ],
+  }),
+)
+
+portableTextToMarkdown(blocks, {schema})
+// a `code` block renders as a fenced code block; a `table` block
+// (undeclared) renders as a `json:object` fence instead
+```
+
+Pass the same schema to `markdownToPortableText` to keep the round trip consistent.

--- a/.changeset/inline-carrier-in-table-cells.md
+++ b/.changeset/inline-carrier-in-table-cells.md
@@ -1,0 +1,11 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: use the inline `json:object` carrier for objects inside table cells
+
+In `portableTextToMarkdown`, an object inside a table cell that renders through the `json:object` carrier now uses the carrier's single-line inline form instead of a block fence squashed with `<br>`.
+
+In `markdownToPortableText`, a carrier object standing alone in a table cell is placed by the schema: it comes back at block position in the cell (`cell.value`), unless the schema declares the type inline-only, in which case it stays an inline child of the cell's text block. The same placement rule now governs standalone images, so under a schema without a block-level `image`, an image alone in a cell stays inline (reported as `image-block-to-inline`) instead of being lifted to block position.
+
+Together the two sides make objects in table cells survive the serialize-edit-reparse round trip.

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -696,7 +696,7 @@ A default renderer (`callout`, `code`, `horizontal-rule`, `html`, `image`, `tabl
 
 The gate reads type names, never field values: declaring a type doesn't validate anything, and a value's fields play no part in which renderer runs. Fields matter on the parse side instead: `markdownToPortableText` filters a construct down to its declared fields, so declare each type with the fields its values carry, or the markdown forms this gate lets through come back rebuilt without them.
 
-An undeclared type falls back to `unknownType`, whose default output is the same `json:object` fence or tagged code span described above, so it round-trips at block and inline positions. Content inside GFM table cells is inline-only, so block-level cell content (fences included) flattens on reparse. Renderers you register in `types` bypass the gate entirely, whether or not the schema declares them.
+An undeclared type falls back to `unknownType`, whose default output is the same `json:object` fence or tagged code span described above, so it round-trips at block and inline positions. Inside a table cell the carrier uses its inline form (a GFM cell is one line), so an undeclared object in a cell survives too; declared types whose markdown form spans multiple lines (a code block in a cell) still flatten on reparse. Renderers you register in `types` bypass the gate entirely, whether or not the schema declares them.
 
 Without a `schema`, every default renderer stays active.
 

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -668,7 +668,41 @@ portableTextToMarkdown(blocks, {
 
 By default, unknown types render as `json:object` fences or tagged code spans that round-trip (see [Round-trip behavior](#round-trip-behavior)), and unknown marks/styles pass through their children unchanged.
 
-You can also customize hard break rendering:
+#### Gating default renderers on a schema
+
+Going to convert the markdown back with `markdownToPortableText`? Pass the same `schema` to both, and nothing the schema can't rebuild becomes markdown that gets destroyed on the way back: undeclared types travel as `json:object` fences that reparse to the same value.
+
+```ts
+import {compileSchema, defineSchema} from '@portabletext/schema'
+
+const schema = compileSchema(
+  defineSchema({
+    blockObjects: [
+      {
+        name: 'code',
+        fields: [
+          {name: 'code', type: 'string'},
+          {name: 'language', type: 'string'},
+        ],
+      },
+    ],
+  }),
+)
+
+portableTextToMarkdown(blocks, {schema})
+```
+
+A default renderer (`callout`, `code`, `horizontal-rule`, `html`, `image`, `table`) runs only when the schema declares that type at the position the node appears in: `blockObjects` for a block, `inlineObjects` for an inline object. An `image` declared in only one of the two still falls back to `unknownType` at the other position.
+
+The gate reads type names, never field values: declaring a type doesn't validate anything, and a value's fields play no part in which renderer runs. Fields matter on the parse side instead: `markdownToPortableText` filters a construct down to its declared fields, so declare each type with the fields its values carry, or the markdown forms this gate lets through come back rebuilt without them.
+
+An undeclared type falls back to `unknownType`, whose default output is the same `json:object` fence or tagged code span described above, so it round-trips at block and inline positions. Content inside GFM table cells is inline-only, so block-level cell content (fences included) flattens on reparse. Renderers you register in `types` bypass the gate entirely, whether or not the schema declares them.
+
+Without a `schema`, every default renderer stays active.
+
+#### Hard breaks
+
+Customize how a hard break (a `\n` inside a span's text) renders:
 
 ```ts
 portableTextToMarkdown(blocks, {

--- a/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
+++ b/packages/markdown/src/from-portable-text/portable-text-to-markdown.ts
@@ -1,3 +1,4 @@
+import type {Schema} from '@portabletext/schema'
 import type {
   ArbitraryTypedObject,
   PortableTextBlock,
@@ -84,6 +85,20 @@ const defaultRenderers: PortableTextRenderers = {
 
 type Options = Partial<PortableTextRenderers> & {
   blockSpacing?: BlockSpacingRenderer
+
+  /**
+   * Compiled schema that gates the built-in type renderers; it never
+   * validates the value. A default renderer runs only when the schema
+   * declares its type (`blockObjects` for block position, `inlineObjects`
+   * for inline); undeclared types render through `unknownType`, whose
+   * default output reparses back to the same value. The gate checks the
+   * type name only, so declare the type's fields too:
+   * `markdownToPortableText` cannot rebuild a value from a fieldless
+   * declaration. Renderers passed in `types` are never gated. Pass the
+   * same schema to `markdownToPortableText` to keep the round trip
+   * consistent. Omitted, all default renderers stay active.
+   */
+  schema?: Schema
 }
 
 /**
@@ -103,7 +118,11 @@ export function portableTextToMarkdown<
       ...options.marks,
     },
     types: {
-      ...defaultRenderers.types,
+      ...gateDefaultTypeRenderers(
+        defaultRenderers.types,
+        options.schema,
+        options.unknownType ?? defaultRenderers.unknownType,
+      ),
       ...options.types,
     },
     hardBreak: options.hardBreak ?? defaultRenderers.hardBreak,
@@ -147,4 +166,29 @@ export function portableTextToMarkdown<
       return `${renderedNode}${blockSpacing}`
     })
     .join('')
+}
+
+function gateDefaultTypeRenderers(
+  defaultTypeRenderers: PortableTextRenderers['types'],
+  schema: Schema | undefined,
+  resolvedUnknownType: PortableTextRenderers['unknownType'],
+): PortableTextRenderers['types'] {
+  if (!schema) {
+    return defaultTypeRenderers
+  }
+
+  return Object.fromEntries(
+    Object.entries(defaultTypeRenderers).map(([typeName, renderer]) => [
+      typeName,
+      (rendererOptions: Parameters<typeof resolvedUnknownType>[0]) => {
+        const declared = (
+          rendererOptions.isInline ? schema.inlineObjects : schema.blockObjects
+        ).some((item) => item.name === typeName)
+
+        return declared && renderer
+          ? renderer(rendererOptions)
+          : resolvedUnknownType(rendererOptions)
+      },
+    ]),
+  )
 }

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -201,14 +201,33 @@ function renderTable(
   // Helper to extract text from cell blocks
   const getCellText = (cellBlocks: Array<TypedObject>): string => {
     return cellBlocks
-      .map((block, index) =>
-        renderNode({
+      .map((block, index) => {
+        const rendered = renderNode({
           node: block,
           index,
           isInline: false,
           renderNode,
-        }),
-      )
+        })
+        const rendererOptions = {
+          value: block,
+          isInline: false,
+          index,
+          renderNode,
+        }
+        if (rendered === DefaultUnknownTypeRenderer(rendererOptions)) {
+          // A GFM cell is one line, so the multi-line fence carrier
+          // would squash into `<br>` soup that reparses as plain text;
+          // the inline carrier is single-line and reparses to the same
+          // value. Exact-matched against the default carrier's output,
+          // so declared markdown forms and custom `unknownType` output
+          // pass through untouched.
+          return DefaultUnknownTypeRenderer({
+            ...rendererOptions,
+            isInline: true,
+          })
+        }
+        return rendered
+      })
       .join(' ')
       .trim()
   }

--- a/packages/markdown/src/markdown-to-portable-text.test.ts
+++ b/packages/markdown/src/markdown-to-portable-text.test.ts
@@ -7551,7 +7551,7 @@ describe(markdownToPortableText.name, () => {
       expect(onDegradation).not.toHaveBeenCalled()
     })
 
-    test('image lifted back to block: standalone image inside a table cell, schema has no block-level `image`', () => {
+    test('image stays inline: standalone image inside a table cell, schema has no block-level `image`', () => {
       const keyGenerator = createTestKeyGenerator()
       const onDegradation = vi.fn<(report: DegradationReport) => void>()
       // `image` only exists as an inline object, so the standalone-image
@@ -7607,7 +7607,20 @@ describe(markdownToPortableText.name, () => {
                   _type: 'cell',
                   _key: 'k6',
                   value: [
-                    {_key: 'k5', _type: 'image', src: 'src.png', alt: 'alt'},
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {
+                          _key: 'k5',
+                          _type: 'image',
+                          src: 'src.png',
+                          alt: 'alt',
+                        },
+                      ],
+                      _key: 'k4',
+                      markDefs: [],
+                    },
                   ],
                 },
               ],
@@ -7616,10 +7629,19 @@ describe(markdownToPortableText.name, () => {
         },
       ])
 
-      // The cell holds nothing but the image, so `td_close`'s sole-image
-      // lift recovers the canonical block-level shape: reporting the
-      // intermediate inline demotion would be a false positive.
-      expect(onDegradation).not.toHaveBeenCalled()
+      // `image` is declared inline-only, which is a legal inline home, so
+      // `td_close`'s sole-object lift declines and the image stays put as
+      // the cell's inline child.
+      expect(onDegradation).toHaveBeenCalledTimes(1)
+      expect(onDegradation.mock.calls[0]![0]!.degradations).toEqual([
+        {
+          type: 'image-block-to-inline',
+          message:
+            'The image became inline: the schema has no block-level `image`',
+          line: 1,
+          snippet: 'alt',
+        },
+      ])
     })
 
     test('image demoted, not lifted: mixed cell content, schema has no block-level `image`', () => {

--- a/packages/markdown/src/portable-text-to-markdown.fuzz.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.fuzz.test.ts
@@ -1,7 +1,20 @@
+import {compileSchema, defineSchema} from '@portabletext/schema'
 import {createTestKeyGenerator} from '@portabletext/test'
 import {isPortableTextBlock, isPortableTextSpan} from '@portabletext/toolkit'
-import type {PortableTextBlock, TypedObject} from '@portabletext/types'
+import type {
+  ArbitraryTypedObject,
+  PortableTextBlock,
+  TypedObject,
+} from '@portabletext/types'
 import {describe, expect, test} from 'vitest'
+import {
+  defaultCalloutObjectDefinition,
+  defaultCodeObjectDefinition,
+  defaultHorizontalRuleObjectDefinition,
+  defaultHtmlObjectDefinition,
+  defaultImageObjectDefinition,
+  defaultTableObjectDefinition,
+} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
 import {markdownToPortableText} from './to-portable-text/markdown-to-portable-text'
 
@@ -429,6 +442,277 @@ describe('portableTextToMarkdown fuzz (seeded, deterministic)', () => {
           .join('\n')
         expect.fail(
           `${failures.length} of ${attempted} fuzz cases failed text identity:\n${sample}`,
+        )
+      }
+    },
+  )
+})
+
+const GATED_TYPE_DEFINITIONS = {
+  'callout': defaultCalloutObjectDefinition,
+  'code': defaultCodeObjectDefinition,
+  'horizontal-rule': defaultHorizontalRuleObjectDefinition,
+  'html': defaultHtmlObjectDefinition,
+  'image': defaultImageObjectDefinition,
+  'table': defaultTableObjectDefinition,
+} as const
+const GATED_TYPE_NAMES = Object.keys(GATED_TYPE_DEFINITIONS) as Array<
+  keyof typeof GATED_TYPE_DEFINITIONS
+>
+
+const GATED_SEEDS = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+const GATED_CASES_PER_SEED = 100
+
+function buildGatedValue(
+  type: keyof typeof GATED_TYPE_DEFINITIONS,
+  keyGenerator: () => string,
+): ArbitraryTypedObject {
+  switch (type) {
+    case 'code':
+      return {
+        _type: 'code',
+        _key: keyGenerator(),
+        code: "const foo = 'bar'",
+        language: 'js',
+      }
+    case 'horizontal-rule':
+      return {_type: 'horizontal-rule', _key: keyGenerator()}
+    case 'html':
+      return {
+        _type: 'html',
+        _key: keyGenerator(),
+        html: '<div class="note">hello</div>',
+      }
+    case 'image':
+      return {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'https://example.com/image.png',
+        alt: 'alt text',
+      }
+    case 'callout':
+      return {
+        _type: 'callout',
+        _key: keyGenerator(),
+        tone: 'note',
+        content: [
+          {
+            _type: 'block',
+            _key: keyGenerator(),
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {
+                _type: 'span',
+                _key: keyGenerator(),
+                text: 'hello',
+                marks: [],
+              },
+            ],
+          },
+        ],
+      }
+    case 'table':
+      return {
+        _type: 'table',
+        _key: keyGenerator(),
+        headerRows: 1,
+        rows: [
+          {
+            _type: 'row',
+            _key: keyGenerator(),
+            cells: [
+              {
+                _type: 'cell',
+                _key: keyGenerator(),
+                value: [
+                  {
+                    _type: 'block',
+                    _key: keyGenerator(),
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: keyGenerator(),
+                        text: 'Header',
+                        marks: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            _type: 'row',
+            _key: keyGenerator(),
+            cells: [
+              {
+                _type: 'cell',
+                _key: keyGenerator(),
+                value: [
+                  {
+                    _type: 'block',
+                    _key: keyGenerator(),
+                    style: 'normal',
+                    markDefs: [],
+                    children: [
+                      {
+                        _type: 'span',
+                        _key: keyGenerator(),
+                        text: 'Cell',
+                        marks: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      }
+  }
+}
+
+function buildGatedPlainTextBlock(
+  random: () => number,
+  keyGenerator: () => string,
+): PortableTextBlock {
+  const length = randomInt(random, 1, 6)
+  let text = ''
+  for (let i = 0; i < length; i++) {
+    text += pick(random, OPAQUE_SAFE_ALPHABET)
+  }
+  return {
+    _type: 'block',
+    _key: keyGenerator(),
+    style: 'normal',
+    markDefs: [],
+    children: [{_type: 'span', _key: keyGenerator(), text, marks: []}],
+  }
+}
+
+interface GeneratedGatedCase {
+  declaredNames: Array<keyof typeof GATED_TYPE_DEFINITIONS>
+  document: Array<ArbitraryTypedObject>
+}
+
+function generateGatedCase(
+  random: () => number,
+  keyGenerator: () => string,
+): GeneratedGatedCase {
+  const declaredNames = GATED_TYPE_NAMES.filter(() => random() < 0.5)
+  const nodeCount = randomInt(random, 1, 3)
+  const document: Array<ArbitraryTypedObject> = []
+  for (let i = 0; i < nodeCount; i++) {
+    if (random() < 0.4) {
+      document.push(buildGatedPlainTextBlock(random, keyGenerator))
+    } else {
+      document.push(
+        buildGatedValue(pick(random, GATED_TYPE_NAMES), keyGenerator),
+      )
+    }
+  }
+  return {declaredNames, document}
+}
+
+/**
+ * Recursively drops `_key`: a declared type's default renderer doesn't
+ * encode keys in markdown, so `markdownToPortableText` assigns fresh ones
+ * on reparse. Comparing gated round trips for content identity means
+ * comparing with keys erased; the two dedicated contract tests already pin
+ * exact key preservation for the fence path.
+ */
+function stripKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stripKeys)
+  }
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(([key]) => key !== '_key')
+        .sort(([a], [b]) => a.localeCompare(b))
+        .map(([key, nested]) => [key, stripKeys(nested)]),
+    )
+  }
+  return value
+}
+
+describe('portableTextToMarkdown schema-gated fuzz (seeded, deterministic)', () => {
+  test(
+    'PT -> MD -> PT content identity under a schema, modulo keys',
+    {timeout: 30_000},
+    () => {
+      const failures: Array<{
+        seed: number
+        caseIndex: number
+        generated: GeneratedGatedCase
+        markdown: string
+        actual: unknown
+      }> = []
+
+      for (const seed of GATED_SEEDS) {
+        const random = mulberry32(seed)
+        for (let caseIndex = 0; caseIndex < GATED_CASES_PER_SEED; caseIndex++) {
+          const buildKeyGenerator = createTestKeyGenerator()
+          const generated = generateGatedCase(random, buildKeyGenerator)
+          const schema = compileSchema(
+            defineSchema({
+              blockObjects: generated.declaredNames.map(
+                (name) => GATED_TYPE_DEFINITIONS[name],
+              ),
+            }),
+          )
+
+          let markdown: string
+          try {
+            markdown = portableTextToMarkdown(generated.document, {schema})
+          } catch (error) {
+            failures.push({
+              seed,
+              caseIndex,
+              generated,
+              markdown: `<threw: ${String(error)}>`,
+              actual: '<n/a>',
+            })
+            continue
+          }
+
+          let actual: unknown
+          try {
+            actual = markdownToPortableText(markdown, {
+              schema,
+              keyGenerator: createTestKeyGenerator(),
+            })
+          } catch (error) {
+            failures.push({
+              seed,
+              caseIndex,
+              generated,
+              markdown,
+              actual: `<threw: ${String(error)}>`,
+            })
+            continue
+          }
+
+          const expected = stripKeys(generated.document)
+          if (JSON.stringify(stripKeys(actual)) !== JSON.stringify(expected)) {
+            failures.push({seed, caseIndex, generated, markdown, actual})
+          }
+        }
+      }
+
+      if (failures.length > 0) {
+        const sample = failures
+          .slice(0, 5)
+          .map(
+            (failure) =>
+              `seed ${failure.seed} case ${failure.caseIndex}: declared ${JSON.stringify(failure.generated.declaredNames)}, document ${JSON.stringify(failure.generated.document)} -> markdown ${JSON.stringify(failure.markdown)} -> got ${JSON.stringify(failure.actual)}`,
+          )
+          .join('\n')
+        expect.fail(
+          `${failures.length} of ${GATED_SEEDS.length * GATED_CASES_PER_SEED} gated fuzz cases failed content identity:\n${sample}`,
         )
       }
     },

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -4399,6 +4399,78 @@ describe(portableTextToMarkdown.name, () => {
       })
     })
 
+    test('a gated type inside a table cell uses the inline carrier and survives', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const cellImageTable = [
+        {
+          _type: 'table',
+          _key: 't1',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  value: [
+                    {
+                      _type: 'image',
+                      _key: 'i1',
+                      src: 'https://example.com/a.png',
+                      alt: 'pic',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      const markdown = portableTextToMarkdown(cellImageTable, {
+        schema: schemaWithTable,
+      })
+      expect(markdown).toEqual(
+        [
+          '| json:object`{"_type":"image","_key":"i1","src":"https://example.com/a.png","alt":"pic"}` |',
+          '| --- |',
+        ].join('\n'),
+      )
+      expect(
+        markdownToPortableText(markdown, {
+          schema: schemaWithTable,
+          keyGenerator,
+        }),
+      ).toEqual([
+        {
+          _type: 'table',
+          _key: 'k3',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k2',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k1',
+                  value: [
+                    {
+                      _type: 'image',
+                      _key: 'i1',
+                      src: 'https://example.com/a.png',
+                      alt: 'pic',
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
     test('a declaration without fields keeps the default renderer', () => {
       const schemaTableNameOnly = compileSchema(
         defineSchema({blockObjects: [{name: 'table'}]}),
@@ -4610,6 +4682,136 @@ describe(portableTextToMarkdown.name, () => {
           _type: 'code',
           _key: 'k0',
           code: '{"_type": "x", "a": 1}',
+        },
+      ])
+    })
+
+    test('an unknown block object inside a table cell uses the inline carrier and survives', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const cellProductTable = [
+        {
+          _type: 'table',
+          _key: 't1',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  value: [{_type: 'product', _key: 'p1', sku: 'abc'}],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      const markdown = portableTextToMarkdown(cellProductTable)
+      expect(markdown).toEqual(
+        [
+          '| json:object`{"_type":"product","_key":"p1","sku":"abc"}` |',
+          '| --- |',
+        ].join('\n'),
+      )
+      expect(markdownToPortableText(markdown, {keyGenerator})).toEqual([
+        {
+          _type: 'table',
+          _key: 'k3',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k2',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k1',
+                  value: [{_type: 'product', _key: 'p1', sku: 'abc'}],
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    })
+
+    test('a declared inline-only object inside a table cell stays inline through the cell round trip', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const schema = compileSchema(
+        defineSchema({
+          blockObjects: [defaultTableObjectDefinition],
+          inlineObjects: [
+            {name: 'stockTicker', fields: [{name: 'symbol', type: 'string'}]},
+          ],
+        }),
+      )
+      const cellStockTickerTable = [
+        {
+          _type: 'table',
+          _key: 't1',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'r1',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'c1',
+                  value: [
+                    {
+                      _type: 'block',
+                      _key: 'b1',
+                      style: 'normal',
+                      markDefs: [],
+                      children: [
+                        {_type: 'stockTicker', _key: 'st1', symbol: 'AAPL'},
+                      ],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ]
+      const markdown = portableTextToMarkdown(cellStockTickerTable, {schema})
+      expect(markdown).toEqual(
+        [
+          '| json:object`{"_type":"stockTicker","_key":"st1","symbol":"AAPL"}` |',
+          '| --- |',
+        ].join('\n'),
+      )
+      expect(markdownToPortableText(markdown, {schema, keyGenerator})).toEqual([
+        {
+          _type: 'table',
+          _key: 'k3',
+          headerRows: 1,
+          rows: [
+            {
+              _type: 'row',
+              _key: 'k2',
+              cells: [
+                {
+                  _type: 'cell',
+                  _key: 'k1',
+                  value: [
+                    {
+                      _type: 'block',
+                      style: 'normal',
+                      children: [
+                        {_type: 'stockTicker', _key: 'st1', symbol: 'AAPL'},
+                      ],
+                      _key: 'k0',
+                      markDefs: [],
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         },
       ])
     })

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -11,7 +11,15 @@ import {
 } from '@portabletext/toolkit'
 import type {PortableTextBlock, TypedObject} from '@portabletext/types'
 import {describe, expect, test} from 'vitest'
-import {defaultSchema} from './default-schema'
+import {
+  defaultCalloutObjectDefinition,
+  defaultCodeObjectDefinition,
+  defaultHorizontalRuleObjectDefinition,
+  defaultHtmlObjectDefinition,
+  defaultImageObjectDefinition,
+  defaultSchema,
+  defaultTableObjectDefinition,
+} from './default-schema'
 import {portableTextToMarkdown} from './from-portable-text/portable-text-to-markdown'
 import {DefaultListItemRenderer} from './from-portable-text/renderers/list-item'
 import {
@@ -4137,6 +4145,343 @@ describe(portableTextToMarkdown.name, () => {
       expect(portableTextToMarkdown(portableText)).toBe(markdown)
     })
   })
+  describe('schema-gated default renderers', () => {
+    const emptySchema = compileSchema(defineSchema({}))
+    const schemaWithTable = compileSchema(
+      defineSchema({
+        blockObjects: [defaultTableObjectDefinition],
+      }),
+    )
+    const schemaImageInlineOnly = compileSchema(
+      defineSchema({
+        inlineObjects: [defaultImageObjectDefinition],
+      }),
+    )
+    const schemaImageBlockOnly = compileSchema(
+      defineSchema({
+        blockObjects: [defaultImageObjectDefinition],
+      }),
+    )
+    const schemaWithAll = compileSchema(
+      defineSchema({
+        blockObjects: [
+          defaultCalloutObjectDefinition,
+          defaultCodeObjectDefinition,
+          defaultHorizontalRuleObjectDefinition,
+          defaultHtmlObjectDefinition,
+          defaultImageObjectDefinition,
+          defaultTableObjectDefinition,
+        ],
+      }),
+    )
+
+    const codeValue = {
+      _type: 'code',
+      _key: 'code1',
+      code: "const foo = 'bar'",
+      language: 'js',
+    }
+    const horizontalRuleValue = {_type: 'horizontal-rule', _key: 'hr1'}
+    const htmlValue = {
+      _type: 'html',
+      _key: 'html1',
+      html: '<div class="note">hello</div>',
+    }
+    const calloutValue = {
+      _type: 'callout',
+      _key: 'callout1',
+      tone: 'note',
+      content: [
+        {
+          _type: 'block',
+          _key: 'cb1',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'cs1', text: 'Content', marks: []}],
+        },
+      ],
+    }
+
+    const imageValue = {
+      _type: 'image',
+      _key: 'img1',
+      src: 'https://example.com/image.png',
+      alt: 'alt text',
+    }
+
+    const tableValue = {
+      _type: 'table',
+      _key: 'table1',
+      headerRows: 1,
+      rows: [
+        {
+          _type: 'row',
+          _key: 'row1',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'cell1',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'block1',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'span1', text: 'Header 1', marks: []},
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'cell',
+              _key: 'cell2',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'block2',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'span2', text: 'Header 2', marks: []},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+        {
+          _type: 'row',
+          _key: 'row2',
+          cells: [
+            {
+              _type: 'cell',
+              _key: 'cell3',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'block3',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'span3', text: 'Cell 1', marks: []},
+                  ],
+                },
+              ],
+            },
+            {
+              _type: 'cell',
+              _key: 'cell4',
+              value: [
+                {
+                  _type: 'block',
+                  _key: 'block4',
+                  style: 'normal',
+                  markDefs: [],
+                  children: [
+                    {_type: 'span', _key: 'span4', text: 'Cell 2', marks: []},
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }
+
+    const tableMarkdown = [
+      '| Header 1 | Header 2 |',
+      '| --- | --- |',
+      '| Cell 1 | Cell 2 |',
+    ].join('\n')
+
+    describe('a type not declared in the schema falls back to the fence', () => {
+      test('code', () => {
+        expect(
+          portableTextToMarkdown([codeValue], {schema: emptySchema}),
+        ).toEqual(
+          ['```json:object', JSON.stringify(codeValue, null, 2), '```'].join(
+            '\n',
+          ),
+        )
+      })
+
+      test('horizontal-rule', () => {
+        expect(
+          portableTextToMarkdown([horizontalRuleValue], {schema: emptySchema}),
+        ).toEqual(
+          [
+            '```json:object',
+            JSON.stringify(horizontalRuleValue, null, 2),
+            '```',
+          ].join('\n'),
+        )
+      })
+
+      test('html', () => {
+        expect(
+          portableTextToMarkdown([htmlValue], {schema: emptySchema}),
+        ).toEqual(
+          ['```json:object', JSON.stringify(htmlValue, null, 2), '```'].join(
+            '\n',
+          ),
+        )
+      })
+
+      test('image', () => {
+        expect(
+          portableTextToMarkdown([imageValue], {schema: emptySchema}),
+        ).toEqual(
+          ['```json:object', JSON.stringify(imageValue, null, 2), '```'].join(
+            '\n',
+          ),
+        )
+      })
+
+      test('callout', () => {
+        expect(
+          portableTextToMarkdown([calloutValue], {schema: emptySchema}),
+        ).toEqual(
+          ['```json:object', JSON.stringify(calloutValue, null, 2), '```'].join(
+            '\n',
+          ),
+        )
+      })
+
+      test('table', () => {
+        expect(
+          portableTextToMarkdown([tableValue], {schema: emptySchema}),
+        ).toEqual(
+          ['```json:object', JSON.stringify(tableValue, null, 2), '```'].join(
+            '\n',
+          ),
+        )
+      })
+    })
+
+    describe('a type declared in the schema renders through its default renderer', () => {
+      test('code', () => {
+        expect(
+          portableTextToMarkdown([codeValue], {schema: schemaWithAll}),
+        ).toEqual(['```js', "const foo = 'bar'", '```'].join('\n'))
+      })
+
+      test('horizontal-rule', () => {
+        expect(
+          portableTextToMarkdown([horizontalRuleValue], {
+            schema: schemaWithAll,
+          }),
+        ).toEqual('---')
+      })
+
+      test('html', () => {
+        expect(
+          portableTextToMarkdown([htmlValue], {schema: schemaWithAll}),
+        ).toEqual('<div class="note">hello</div>')
+      })
+
+      test('image', () => {
+        expect(
+          portableTextToMarkdown([imageValue], {schema: schemaWithAll}),
+        ).toEqual('![alt text](https://example.com/image.png)')
+      })
+
+      test('callout', () => {
+        expect(
+          portableTextToMarkdown([calloutValue], {schema: schemaWithAll}),
+        ).toEqual('> [!NOTE]\n> Content')
+      })
+
+      test('table', () => {
+        expect(
+          portableTextToMarkdown([tableValue], {schema: schemaWithTable}),
+        ).toEqual(tableMarkdown)
+      })
+    })
+
+    test('a declaration without fields keeps the default renderer', () => {
+      const schemaTableNameOnly = compileSchema(
+        defineSchema({blockObjects: [{name: 'table'}]}),
+      )
+      expect(
+        portableTextToMarkdown([tableValue], {schema: schemaTableNameOnly}),
+      ).toEqual(tableMarkdown)
+    })
+
+    test('an inline `image` declared only in `blockObjects` falls back to the tagged code span', () => {
+      const inlineImageValue = {
+        _type: 'image',
+        _key: 'img2',
+        src: 'https://example.com/icon.png',
+        alt: 'icon',
+      }
+      expect(
+        portableTextToMarkdown(
+          [
+            {
+              _type: 'block',
+              _key: 'b1',
+              style: 'normal',
+              markDefs: [],
+              children: [
+                {_type: 'span', _key: 's1', text: 'before ', marks: []},
+                inlineImageValue,
+                {_type: 'span', _key: 's2', text: ' after', marks: []},
+              ],
+            },
+          ],
+          {schema: schemaImageBlockOnly},
+        ),
+      ).toEqual(
+        `before json:object\`${JSON.stringify(inlineImageValue)}\` after`,
+      )
+    })
+
+    test('a block-position `image` declared only in `inlineObjects` falls back to the fence', () => {
+      expect(
+        portableTextToMarkdown([imageValue], {
+          schema: schemaImageInlineOnly,
+        }),
+      ).toEqual(
+        ['```json:object', JSON.stringify(imageValue, null, 2), '```'].join(
+          '\n',
+        ),
+      )
+    })
+
+    test('an explicit `types` renderer overrides the gate', () => {
+      expect(
+        portableTextToMarkdown([tableValue], {
+          schema: emptySchema,
+          types: {table: DefaultTableRenderer},
+        }),
+      ).toEqual(tableMarkdown)
+    })
+
+    test('a custom `unknownType` renderer receives the gated node', () => {
+      expect(
+        portableTextToMarkdown([tableValue], {
+          schema: emptySchema,
+          unknownType: ({value}) => `custom:${value._type}`,
+        }),
+      ).toEqual('custom:table')
+    })
+
+    test('without a `schema`, the default renderer still applies', () => {
+      expect(portableTextToMarkdown([tableValue])).toEqual(tableMarkdown)
+    })
+
+    test('the fence round-trips back to the original value under the same schema', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const markdown = portableTextToMarkdown([tableValue], {
+        schema: emptySchema,
+      })
+      expect(
+        markdownToPortableText(markdown, {schema: emptySchema, keyGenerator}),
+      ).toEqual([tableValue])
+    })
+  })
+
   describe('unknown block object (`json:object` fence)', () => {
     test('serializes as a `json:object` fence with the value as pretty JSON', () => {
       const value = {

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -1992,10 +1992,15 @@ export function markdownToPortableText(
           }
         }
 
-        // Check if the cell contains a single block with a single image child
-        // If so, extract the image as a block-level image
+        // A cell holding one block whose only child is an object (not a
+        // span) lifts that object to block position, unless the schema
+        // declares the type inline-only: that type has a legal inline home,
+        // so the block reading would manufacture a placement the schema
+        // forbids. Everything else (declared block, declared both, or
+        // undeclared) reads as block, matching PT's table model where
+        // `cell.value` is an array of blocks.
         const firstBlock = cellBlocks[0]
-        let liftedImage: PortableTextObject | undefined
+        let liftedObject: PortableTextObject | undefined
         if (
           cellBlocks.length === 1 &&
           firstBlock &&
@@ -2005,17 +2010,23 @@ export function markdownToPortableText(
           firstBlock.children.length === 1
         ) {
           const onlyChild = firstBlock.children[0]
-          // Check if it's an image object (not a span)
           if (
             typeof onlyChild === 'object' &&
             onlyChild !== null &&
             '_type' in onlyChild &&
-            onlyChild._type !== consolidatedOptions.schema.span.name &&
-            onlyChild._type === 'image'
+            onlyChild._type !== consolidatedOptions.schema.span.name
           ) {
-            // Replace the block with just the image
-            cellBlocks[0] = onlyChild as PortableTextBlock
-            liftedImage = onlyChild as PortableTextObject
+            const declaredInline =
+              consolidatedOptions.schema.inlineObjects.some(
+                (inlineObject) => inlineObject.name === onlyChild._type,
+              )
+            const declaredBlock = consolidatedOptions.schema.blockObjects.some(
+              (blockObject) => blockObject.name === onlyChild._type,
+            )
+            if (!(declaredInline && !declaredBlock)) {
+              cellBlocks[0] = onlyChild as PortableTextBlock
+              liftedObject = onlyChild as PortableTextObject
+            }
           }
         }
 
@@ -2023,7 +2034,7 @@ export function markdownToPortableText(
         // child of the cell's text block: report it now that the verdict is
         // known, instead of at demotion time.
         for (const demotedImage of demotedInlineImages) {
-          if (demotedImage !== liftedImage) {
+          if (demotedImage !== liftedObject) {
             const {alt, src} = demotedImage as {alt?: string; src?: string}
             report({
               type: 'image-block-to-inline',

--- a/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
+++ b/packages/markdown/src/to-portable-text/markdown-to-portable-text.ts
@@ -107,6 +107,11 @@ export type Degradation = {
 }
 
 type Options = {
+  /**
+   * Compiled schema deciding which Portable Text constructs the
+   * conversion may build; pairs with the same option on
+   * `portableTextToMarkdown` to keep the round trip consistent.
+   */
   schema?: Schema
   keyGenerator?: () => string
   /**


### PR DESCRIPTION
The two conversion directions disagree about the schema, and the disagreement destroys content. `markdownToPortableText` is schema-gated per object type: a construct whose type the schema doesn't declare degrades, named and reported (`table-flattened`, `code-block-to-text`, and kin). `portableTextToMarkdown` was shape-keyed and schema-blind: any `table`-shaped block became a GFM table, any `code`-shaped block a fence. So a value holding a shape its schema can't rebuild serialized to a pretty markdown form and was destroyed by its own reparse, while the `json:object` carrier, which reparses to the same value under any schema, sat one fallback away. For edit workflows that serialize, let something edit the markdown, and parse it back (#3242), that's silent data loss on exactly the documents that need custom types most.

`portableTextToMarkdown` now takes an optional `schema`, the same compiled `Schema` the parse side takes:

```ts
const schema = compileSchema(
  defineSchema({
    blockObjects: [
      {
        name: 'code',
        fields: [
          {name: 'code', type: 'string'},
          {name: 'language', type: 'string'},
        ],
      },
    ],
  }),
)

portableTextToMarkdown(blocks, {schema})
// a `code` block renders as a fenced code block; a `table` block
// (undeclared) renders as a `json:object` fence that reparses verbatim
```

The gate wraps the six default type renderers at the renderer-merge point, so precedence falls out of the existing merge: explicit `types` entries are never gated (the `types: {table: undefined}` knockout keeps working), and undeclared types render through the resolved `unknownType`, so a custom `unknownType` receives the gated nodes (pinned). Membership is strict by position, `blockObjects` for block position and `inlineObjects` for inline, mirroring the parse side's `buildObjectMatcher`; an `image` declared only inline fences at block position rather than serializing into a position-shifting reparse (both directions pinned). Without `schema` the renderer merge is untouched (pinned, plus the whole existing suite).

A second, separable fix ships as its own commit and changeset, active with or without `schema`: a GFM cell is one line, so the block fence carrier inside a table cell used to squash into `<br>` soup that reparsed as gibberish. Cells now re-emit the default carrier in its single-line inline form (swapped only when the rendered output exactly equals the default carrier's, so declared markdown forms and custom `unknownType` output pass through untouched), and an object riding the carrier inside a cell survives the round trip, the parse side's standalone-image lift generalized to any sole object child of a cell's only block and schema-gated: declared inline-only stays wrapped in the cell's text block (its legal home), declared-block and undeclared types come back at block position. Pinned gated, ungated, and inline-only, each proven red. One parse behavior flips with it: a standalone cell image under a schema without block-level `image` now stays inline and reports, instead of lifting into a placement the schema forbids. Declared types whose markdown form is multi-line, a code block in a cell, still flatten on reparse; that limit is GFM's, not ours.

One honest limit remains by choice: the gate checks the type name only, so a fieldless declaration keeps the default renderer even though the parse side cannot rebuild a fieldless value; field-aware gating would duplicate each parse matcher's field requirements in a second place, so the docs say "declare the fields" and the name-only behavior is pinned as a contract. The contract landed first as 18 pins (10 proven red pre-gate) and grew three more (fieldless declaration, the two cell-carrier pins), and a seeded fuzz property round-trips random documents under random schema subsets: without the gate it fails 467 of 1000 cases. The fuzz generates top-level block positions only; the inline and cell branches rest on the directed pins.

This merges before #3242: with one schema on both sides, its internal canonicalization stops destroying undeclared types, and its "pass the same serialize options" requirement collapses to "pass the same schema".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serialization and table-cell reparse behavior for consumers using custom schemas or edit round-trips; default no-schema path is unchanged but inline-only image-in-cell now degrades with a report instead of silent lift.
> 
> **Overview**
> **`portableTextToMarkdown`** gains an optional **`schema`** so built-in type renderers (`callout`, `code`, `horizontal-rule`, `html`, `image`, `table`) run only when that type is declared at the node’s position (`blockObjects` vs `inlineObjects`). Undeclared types serialize through **`unknownType`** (default `json:object` fence/span) so PT→MD→PT can preserve values the parse schema cannot rebuild. Explicit **`types`** overrides are never gated; omitting **`schema`** keeps prior behavior.
> 
> **Table cells:** objects that use the default carrier now emit the **inline** `json:object` form in GFM cells instead of a block fence that breaks on reparse. **`markdownToPortableText`** applies the same schema-aware placement for a lone object in a cell (inline-only types stay in the text block; otherwise lift to `cell.value`), including standalone images without block-level `image` (now **`image-block-to-inline`** instead of forbidden block lift).
> 
> Docs/changesets and broad unit + seeded fuzz coverage document the contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd355f20e69cb05752c2dcdb2114e0c9bc60811. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->