### PR TITLE
fix: remove the local placeholder on a remote root `insert` after a self-emitted `unset`

### DIFF
--- a/.changeset/remove-placeholder-on-remote-insert-after-unset.md
+++ b/.changeset/remove-placeholder-on-remote-insert-after-unset.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: remove the local placeholder on a remote root `insert` after a self-emitted `unset`
+
+After clearing the field under a value-mirroring host, a collaborator's block arriving through `patches` no longer leaves an extra empty block in the editor; the editor shows only the collaborator's content. One additional change: an empty block that a host genuinely persisted in the window after the editor's own `unset` is now removed from the editor when a remote root `insert` arrives, until the next value sync restores it; distinguishing it from the editor's own placeholder takes provenance metadata, which is follow-up work.

--- a/packages/editor/src/internal-utils/applyPatch.ts
+++ b/packages/editor/src/internal-utils/applyPatch.ts
@@ -151,11 +151,15 @@ function insertPatch(
       editor.snapshot.context.value,
       context.schema,
     ) &&
-    !isEqualValues(
-      {schema: context.schema},
-      editor.lastSyncedValue,
-      editor.snapshot.context.value,
-    )
+    (editor.valueUnsetEmitted ||
+      // Mirrors `editorWasEmpty` in `subscriber.patch-generation.ts`: once
+      // this editor's stream has unset the field, a value-equal recording
+      // is not proof of persistence.
+      !isEqualValues(
+        {schema: context.schema},
+        editor.lastSyncedValue,
+        editor.snapshot.context.value,
+      ))
 
   const arrayFieldPath = patch.path.slice(0, -1)
 

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -93,9 +93,9 @@ export interface PortableTextEditorEngine extends DOMEditor {
    * True while this editor's own emitted patch stream has destroyed the
    * field (a root `unset([])` went out) and not yet re-materialized it (a
    * root `setIfMissing` or `set` went out since). While true, patch
-   * generation rebuilds the field before targeting it again and treats a
-   * placeholder equal to `lastSyncedValue` as unpersisted rather than as
-   * proof the field survived.
+   * generation rebuilds the field before targeting it again, and both it
+   * and remote root inserts treat a placeholder equal to `lastSyncedValue`
+   * as unpersisted rather than as proof the field survived.
    */
   valueUnsetEmitted: boolean
   isPatching: boolean

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5679,6 +5679,108 @@ describe('event.patches', () => {
     })
   })
 
+  test('Scenario: A remote root `insert` after a self-emitted `unset` removes even a recorded placeholder', async () => {
+    const remoteBazBlock = {
+      _type: 'block',
+      _key: 'c0',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'c1', text: 'baz', marks: []}],
+    }
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // Build the same poisoned recording as 'Retyping after a
+    // character-by-character clear when the host mirrors values': a
+    // stale mirrored echo lands after the editor's own `unset([])` and
+    // records the placeholder as the last synced value. A remote root
+    // `insert` must override that recording the same way the local
+    // retype does.
+    editor.on('mutation', (event) => {
+      editor.send({type: 'update value', value: event.value})
+    })
+    let remoteOperations = 0
+    editor.on('operation', (event) => {
+      if (event.origin === 'remote') {
+        remoteOperations++
+      }
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'k0'}, 'children', {_key: 'k1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('fo', 'foo'))),
+        origin: 'local',
+      })
+    })
+
+    await userEvent.keyboard('{Backspace}{Backspace}{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    await vi.waitFor(() => {
+      expect(remoteOperations).toBeGreaterThan(0)
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k1', text: '', marks: []}],
+        },
+      ])
+    })
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {type: 'setIfMissing', path: [], value: [], origin: 'remote'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [remoteBazBlock],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [remoteBazBlock],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'c0',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'c1', text: 'baz', marks: []}],
+        },
+      ])
+    })
+  })
+
   test('Scenario: a behavior raising root `unset` then `insert.block` in one action set emits an applicable patch stream', async () => {
     const patches: Array<Patch> = []
     const keyGenerator = createTestKeyGenerator()


### PR DESCRIPTION
After clearing a Portable Text field under a host that mirrors `mutation.value` back into `update value`, a collaborator's block arriving through `patches` left a phantom block behind: the editor showed its local placeholder next to the inserted block while the document held only the block, and text typed into the phantom emitted patches against a span no store has, so it never persisted.

The cause is the same poisoned recording #3253's sibling fix guards against in patch generation. A lagging mirror echo of the cleared state records the editor's own placeholder as the last synced value, and `insertPatch`'s root-insert handling decided whether to remove the placeholder from that equality alone, reading the poison as proof of persistence. The predicate now mirrors patch generation's: while this editor's own stream has unset the field (`valueUnsetEmitted`), a value-equal placeholder is treated as unpersisted and removed. The remote write deliberately does not clear the flag; only the editor's own emitted rebuild does.

One additional change, deliberate and pinned by the test: a lone empty block that a host genuinely persisted inside this window is indistinguishable by value from the placeholder, so it is now also removed when a remote root insert arrives, until the next value sync restores it. Telling the two apart takes provenance metadata, which is follow-up work. Behavior is unchanged whenever the editor has not unset the field itself: pristine blocks synced in without a preceding local clear keep suppressing the removal through the existing equality, pinned by the existing scenarios.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collaborative patch application and empty-editor placeholder logic; incorrect handling could drop blocks or show duplicates, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes a **collaboration bug** where, after the local editor clears the field (`unset`) under a host that mirrors `mutation.value` back, a **remote root `insert`** could leave a phantom empty block beside the collaborator’s content.
> 
> **`insertPatch`** now uses the same **`editorWasEmptyBefore`** rule as patch generation: when **`valueUnsetEmitted`** is set, a placeholder that still matches **`lastSyncedValue`** (including a stale mirror echo) is treated as **unpersisted**, so the empty block is removed when applying the remote insert. Docs on **`valueUnsetEmitted`** are updated to note this applies to remote root inserts too.
> 
> **Trade-off:** a genuinely persisted empty block after a local unset may also be dropped until the next value sync; separating that from the editor placeholder needs provenance metadata (called out as follow-up). Behavior when the editor has **not** locally unset is unchanged.
> 
> Adds a regression test for the mirror-echo + remote insert scenario and a changeset for `@portabletext/editor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4591bb6081e0fe2c3b0b87623a47c8c0a7c667a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->