### PR TITLE
fix: classify `update value` echoes by the editor's own emitted values

### DIFF
--- a/.changeset/classify-update-value-echoes.md
+++ b/.changeset/classify-update-value-echoes.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/editor': patch
+---
+
+fix: classify `update value` echoes by the editor's own emitted values
+
+After clearing a field, an empty block the host genuinely persisted is no longer re-inserted (duplicate `_key`) by the next keystroke. Blocks a collaborator creates through `patches` count as persisted content on the first local edit, not the editor's own placeholder. And a genuinely persisted empty block is no longer removed when a collaborator's root `insert` arrives right after the editor's own clear.

--- a/.changeset/remove-placeholder-on-remote-insert-after-unset.md
+++ b/.changeset/remove-placeholder-on-remote-insert-after-unset.md
@@ -4,4 +4,4 @@
 
 fix: remove the local placeholder on a remote root `insert` after a self-emitted `unset`
 
-After clearing the field under a value-mirroring host, a collaborator's block arriving through `patches` no longer leaves an extra empty block in the editor; the editor shows only the collaborator's content. One additional change: an empty block that a host genuinely persisted in the window after the editor's own `unset` is now removed from the editor when a remote root `insert` arrives, until the next value sync restores it; distinguishing it from the editor's own placeholder takes provenance metadata, which is follow-up work.
+After clearing the field under a value-mirroring host, a collaborator's block arriving through `patches` no longer leaves an extra empty block in the editor; the editor shows only the collaborator's content.

--- a/.changeset/root-unset-rematerialization.md
+++ b/.changeset/root-unset-rematerialization.md
@@ -6,4 +6,4 @@ fix: re-materialize the field before patches emitted while it is unset
 
 A behavior replacing the whole value in one action set (a root `unset` followed by an `insert`) previously emitted a patch stream that patch-applying stores could not apply: an `insert` into a field the preceding `unset` had removed. Consumers saw `Cannot apply deep operations on primitive values`.
 
-One narrow behavioral fix rides along: clearing the editor through a behavior-raised root `unset` now re-materializes the field on the next edit under a value-mirroring host, the same way clearing it with the keyboard already did.
+One additional change: clearing the editor through a behavior-raised root `unset` now re-materializes the field on the next edit under a value-mirroring host, the same way clearing it with the keyboard already did.

--- a/packages/editor/src/editor/create-editor-engine.tsx
+++ b/packages/editor/src/editor/create-editor-engine.tsx
@@ -77,6 +77,7 @@ export function createEditorEngine(
 
   editor.isDeferringMutations = false
   editor.lastSyncedValue = undefined
+  editor.emittedValues = []
   editor.valueUnsetEmitted = false
   editor.isPatching = true
   editor.isPerformingBehaviorOperation = false

--- a/packages/editor/src/editor/mutation-batcher.test.ts
+++ b/packages/editor/src/editor/mutation-batcher.test.ts
@@ -17,6 +17,7 @@ const TYPE_DEBOUNCE = 250
 function createTestHarness({readOnly = false}: {readOnly?: boolean} = {}) {
   const editorEngine = createEditor() as PortableTextEditorEngine
   editorEngine.isDeferringMutations = false
+  editorEngine.emittedValues = []
 
   let isReadOnly = readOnly
   let patchListener:

--- a/packages/editor/src/editor/mutation-batcher.ts
+++ b/packages/editor/src/editor/mutation-batcher.ts
@@ -14,6 +14,13 @@ type PendingMutation = {
 
 const TYPE_DEBOUNCE = 250
 
+// Bounds `editorEngine.emittedValues`. Entries cannot pile up while
+// `valueUnsetEmitted` is armed: only content-producing local edits flush
+// mutations, and any such edit disarms the flag via its own rebuild. The
+// cap instead bounds memory and the false-echo horizon for hosts that
+// round-trip values old enough to no longer reflect this editor's state.
+const EMITTED_VALUES_LIMIT = 50
+
 // A typed burst splits into two mutations mid-word if this fixed flush cadence
 // fires before the burst finishes typing, so in test mode the interval has to
 // be comfortably longer than a real burst takes to type. It also can't be too
@@ -122,6 +129,16 @@ export function createMutationBatcher({
     editorEngine.isDeferringMutations = false
 
     for (const bulk of mutations) {
+      if (bulk.value !== undefined) {
+        editorEngine.emittedValues.push(bulk.value)
+        if (editorEngine.emittedValues.length > EMITTED_VALUES_LIMIT) {
+          editorEngine.emittedValues.splice(
+            0,
+            editorEngine.emittedValues.length - EMITTED_VALUES_LIMIT,
+          )
+        }
+      }
+
       // The editor machine still gates mutations through its setup states
       // and re-emits them to the relay.
       editorActor.send({

--- a/packages/editor/src/editor/remote-patches.ts
+++ b/packages/editor/src/editor/remote-patches.ts
@@ -7,6 +7,7 @@ import {withoutNormalizing} from '../engine/editor/without-normalizing'
 import {createApplyPatch} from '../internal-utils/applyPatch'
 import {debug} from '../internal-utils/debug'
 import {safeStringify} from '../internal-utils/safe-json'
+import {isEqualToEmptyEditor} from '../internal-utils/values'
 import type {PortableTextEditorEngine} from '../types/editor-engine'
 import type {EditorActor} from './editor-machine'
 
@@ -24,7 +25,8 @@ export function setupRemotePatches({
   subscriptions: Array<() => () => void>
   editor: PortableTextEditorEngine
 }): void {
-  const applyPatch = createApplyPatch(editorActor.getSnapshot().context)
+  const context = editorActor.getSnapshot().context
+  const applyPatch = createApplyPatch(context)
 
   let bufferedPatches: Patch[] = []
 
@@ -34,7 +36,17 @@ export function setupRemotePatches({
     }
     const patches = bufferedPatches
     bufferedPatches = []
-    let changed = false
+    let batchChanged = false
+    let rootMaterializingPatchApplied = false
+
+    const engineWasEmptyOrPlaceholder =
+      editor.snapshot.context.value.length === 0 ||
+      (editor.snapshot.context.value.length === 1 &&
+        isEqualToEmptyEditor(
+          context.initialValue,
+          editor.snapshot.context.value,
+          context.schema,
+        ))
 
     withRemoteChanges(editor, 'patches', () => {
       withoutNormalizing(editor, () => {
@@ -42,10 +54,28 @@ export function setupRemotePatches({
           pluginWithoutHistory(editor, () => {
             for (const patch of patches) {
               try {
-                changed = applyPatch(editor, patch)
+                const patchChanged = applyPatch(editor, patch)
+
+                if (patchChanged) {
+                  batchChanged = true
+
+                  // A `setIfMissing` never counts on its own: it can leave
+                  // the editor holding only its normalization-minted
+                  // placeholder, and recording that would claim the host
+                  // persists a block it does not have.
+                  if (
+                    (patch.type === 'insert' && patch.path.length === 1) ||
+                    (patch.type === 'set' &&
+                      patch.path.length === 0 &&
+                      Array.isArray(patch.value) &&
+                      patch.value.length > 0)
+                  ) {
+                    rootMaterializingPatchApplied = true
+                  }
+                }
 
                 if (debug.syncPatch.enabled) {
-                  if (changed) {
+                  if (patchChanged) {
                     debug.syncPatch(`(applied) ${safeStringify(patch, 2)}`)
                   } else {
                     debug.syncPatch(`(ignored) ${safeStringify(patch, 2)}`)
@@ -60,9 +90,14 @@ export function setupRemotePatches({
           })
         })
       })
-      if (changed) {
+      if (batchChanged) {
         normalize(editor)
         editor.onChange()
+
+        if (engineWasEmptyOrPlaceholder && rootMaterializingPatchApplied) {
+          editor.lastSyncedValue = editor.snapshot.context.value
+          editor.valueUnsetEmitted = false
+        }
       }
     })
   }

--- a/packages/editor/src/editor/subscriber.patch-generation.ts
+++ b/packages/editor/src/editor/subscriber.patch-generation.ts
@@ -49,9 +49,10 @@ export function subscribePatchGeneration({
       isEqualToEmptyEditor(initialValue, previousValue, schema) &&
       // After this editor emits `unset([])`, its own stream must
       // re-materialize the field before targeting it again, no matter what
-      // value sync recorded in between: a mirroring host's stale echo of
-      // the cleared state syncs as a genuine write and would otherwise
-      // pass the placeholder off as persisted content.
+      // value sync recorded in between: a mirroring host's echo of the
+      // cleared state that has aged out of the emitted-values ledger
+      // still syncs as a genuine write and would otherwise pass the
+      // placeholder off as persisted content.
       (editor.valueUnsetEmitted ||
         !isEqualValues({schema}, editor.lastSyncedValue, previousValue))
 

--- a/packages/editor/src/editor/sync-machine.test.ts
+++ b/packages/editor/src/editor/sync-machine.test.ts
@@ -17,6 +17,7 @@ function createTestEngine(keyGenerator: () => string) {
   e.containers = new Map()
   e.blockIndexMap = new Map()
   e.verifiedUniqueChildGroups = new Set()
+  e.emittedValues = []
   e.snapshot = {
     blockIndexMap: e.blockIndexMap,
     context: {

--- a/packages/editor/src/editor/sync-machine.ts
+++ b/packages/editor/src/editor/sync-machine.ts
@@ -169,11 +169,24 @@ export const syncMachine = setup({
     }),
     'record synced value on engine': ({context, event}) => {
       assertEvent(event, 'done syncing')
-      if (event.changed) {
+      if (!event.changed) {
         // A sync that wrote nothing is not a host persistence claim; see
         // `lastSyncedValue`.
-        context.editorEngine.lastSyncedValue = event.value
+        return
       }
+
+      const {emittedValues} = context.editorEngine
+      const echoIndex = emittedValues.findIndex((value) =>
+        isEqualValues({schema: context.schema}, value, event.value),
+      )
+
+      if (echoIndex !== -1) {
+        emittedValues.splice(0, echoIndex + 1)
+        return
+      }
+
+      context.editorEngine.lastSyncedValue = event.value
+      context.editorEngine.valueUnsetEmitted = false
     },
     'emit done syncing value': emit({
       type: 'done syncing value',

--- a/packages/editor/src/types/editor-engine.ts
+++ b/packages/editor/src/types/editor-engine.ts
@@ -81,21 +81,34 @@ export interface PortableTextEditorEngine extends DOMEditor {
 
   isDeferringMutations: boolean
   /**
-   * The last host value recorded by a value sync that changed the engine. A
+   * The last host value recorded as genuinely persisted content. A
    * pristine block equal to it is persisted content, not the local
-   * placeholder. Syncs that write nothing are not recorded: hosts mirror
-   * `mutation.value` back as `update value`, and such an echo of the
-   * editor's own state (its placeholder included) is not a claim that the
-   * value is persisted.
+   * placeholder. Two things write it: a value sync that changes the
+   * engine with a value not classified as an echo of this editor's own
+   * emitted state (see `emittedValues`), and a remote `patches` batch that
+   * re-materializes an empty or placeholder root with a root `insert` or a
+   * non-empty root `set`.
    */
   lastSyncedValue: Array<PortableTextBlock> | undefined
   /**
+   * The bounded ledger of engine values this editor has emitted with its
+   * `mutation` events. An `update value` equal to an entry is the host
+   * echoing this editor's own state back and asserts nothing about
+   * persistence.
+   */
+  emittedValues: Array<Array<PortableTextBlock>>
+  /**
    * True while this editor's own emitted patch stream has destroyed the
-   * field (a root `unset([])` went out) and not yet re-materialized it (a
-   * root `setIfMissing` or `set` went out since). While true, patch
-   * generation rebuilds the field before targeting it again, and both it
-   * and remote root inserts treat a placeholder equal to `lastSyncedValue`
-   * as unpersisted rather than as proof the field survived.
+   * field (a root `unset([])` went out) and not yet re-materialized it.
+   * Three things disarm it: this editor's own emitted rebuild (a root
+   * `setIfMissing` or `set` patch going out), a value sync that changes
+   * the engine with a value not classified as an echo of this editor's own
+   * emitted state, and a remote `patches` batch that re-materializes an
+   * empty or placeholder root with a root `insert` or a non-empty root
+   * `set`. While true, patch generation rebuilds the field before
+   * targeting it again, and both it and remote root inserts treat a
+   * placeholder equal to `lastSyncedValue` as unpersisted rather than as
+   * proof the field survived.
    */
   valueUnsetEmitted: boolean
   isPatching: boolean

--- a/packages/editor/tests/event.patches.test.tsx
+++ b/packages/editor/tests/event.patches.test.tsx
@@ -5537,10 +5537,11 @@ describe('event.patches', () => {
 
     // Unlike the single-flush clear above, a character-by-character clear
     // spreads across flushes, so the mirrored echoes race the ongoing
-    // edits: a stale echo differs from the engine by then, syncs as a
-    // genuine write, and records the placeholder as the last synced
-    // value. The editor's own `unset([])` emission must override that:
-    // its stream destroyed the field, so the retype must rebuild it.
+    // edits: a stale echo differs from the engine by then, but the ledger
+    // still recognizes it as this editor's own emitted state and skips
+    // recording it. The retype below survives on `valueUnsetEmitted`
+    // alone, armed by the editor's own `unset([])` emission and never
+    // touched by these echoes.
     editor.on('mutation', (event) => {
       editor.send({type: 'update value', value: event.value})
     })
@@ -5575,8 +5576,8 @@ describe('event.patches', () => {
 
     // The echo cascade settles when a stale echo has written into the
     // engine (a remote-origin operation) and the last write restored the
-    // placeholder. Only then has the poisoned value been recorded, which
-    // is the state the retype below must survive.
+    // placeholder. Only then has every echo been absorbed by the ledger,
+    // which is the state the retype below must survive.
     await vi.waitFor(() => {
       expect(remoteOperations).toBeGreaterThan(0)
       expect(editor.getSnapshot().context.value).toEqual([
@@ -5679,7 +5680,7 @@ describe('event.patches', () => {
     })
   })
 
-  test('Scenario: A remote root `insert` after a self-emitted `unset` removes even a recorded placeholder', async () => {
+  test('Scenario: A remote root `insert` after a self-emitted `unset` removes the placeholder', async () => {
     const remoteBazBlock = {
       _type: 'block',
       _key: 'c0',
@@ -5702,12 +5703,12 @@ describe('event.patches', () => {
       ),
     })
 
-    // Build the same poisoned recording as 'Retyping after a
-    // character-by-character clear when the host mirrors values': a
-    // stale mirrored echo lands after the editor's own `unset([])` and
-    // records the placeholder as the last synced value. A remote root
-    // `insert` must override that recording the same way the local
-    // retype does.
+    // Build the same echo race as 'Retyping after a character-by-character
+    // clear when the host mirrors values': a stale mirrored echo lands
+    // after the editor's own `unset([])`, but the ledger recognizes it and
+    // skips recording it. A remote root `insert` must still rebuild the
+    // field the same way the local retype does, relying on
+    // `valueUnsetEmitted` alone.
     editor.on('mutation', (event) => {
       editor.send({type: 'update value', value: event.value})
     })
@@ -6251,6 +6252,411 @@ describe('event.patches', () => {
           value: stringifyPatches(makePatches(makeDiff('', 'a'))),
           origin: 'local',
         },
+      ])
+    })
+  })
+
+  test('Scenario: Typing after a local clear into a genuine pristine block synced in via `update value`', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    const patchCountAfterClear = patches.length
+
+    const pristineForeignBlock: PortableTextBlock = {
+      _key: 'c0',
+      _type: 'block',
+      children: [{_key: 'c1', _type: 'span', text: '', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    editor.send({type: 'update value', value: [pristineForeignBlock]})
+
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          pristineForeignBlock,
+        ])
+      },
+      {timeout: 5000},
+    )
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'y')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterClear)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'c0'}, 'children', {_key: 'c1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'y'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Typing into a genuine pristine block synced in via `update value` after intervening non-pristine content', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    const nonPristineForeignBlock: PortableTextBlock = {
+      _key: 'c0',
+      _type: 'block',
+      children: [{_key: 'c1', _type: 'span', text: 'bar', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    editor.send({type: 'update value', value: [nonPristineForeignBlock]})
+
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          nonPristineForeignBlock,
+        ])
+      },
+      {timeout: 5000},
+    )
+
+    await userEvent.click(locator)
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'c0'}, 'children', {_key: 'c1'}], offset: 3},
+        focus: {path: [{_key: 'c0'}, 'children', {_key: 'c1'}], offset: 3},
+      },
+    })
+    await userEvent.type(locator, 'z')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'diffMatchPatch',
+        path: [{_key: 'c0'}, 'children', {_key: 'c1'}, 'text'],
+        value: stringifyPatches(makePatches(makeDiff('bar', 'barz'))),
+        origin: 'local',
+      })
+    })
+
+    const patchCountAfterDetourEdit = patches.length
+
+    const pristineForeignBlock: PortableTextBlock = {
+      _key: 'c2',
+      _type: 'block',
+      children: [{_key: 'c3', _type: 'span', text: '', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    editor.send({type: 'update value', value: [pristineForeignBlock]})
+
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          pristineForeignBlock,
+        ])
+      },
+      {timeout: 5000},
+    )
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'y')
+
+    await vi.waitFor(() => {
+      expect(patches.slice(patchCountAfterDetourEdit)).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'c2'}, 'children', {_key: 'c3'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'y'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Typing into a pristine block created by remote `patches`', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    const pristineForeignBlock = {
+      _key: 'c0',
+      _type: 'block',
+      children: [{_key: 'c1', _type: 'span', text: '', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {type: 'setIfMissing', path: [], value: [], origin: 'remote'},
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [pristineForeignBlock],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [pristineForeignBlock],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([pristineForeignBlock])
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'y')
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'c0'}, 'children', {_key: 'c1'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'y'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: Typing after a remote root `setIfMissing` on an empty editor still rebuilds the field', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    // The `unset` genuinely empties the root for the moment it takes
+    // `setIfMissing` to reassert it: only then does `setIfMissing` apply
+    // (against a placeholder-holding root it always bails) and only then
+    // does normalization mint a fresh placeholder for it to leave behind.
+    // Neither patch qualifies as a root materialization on its own, so the
+    // retype below must still rebuild the field exactly as it would have
+    // before the recording was narrowed.
+    editor.send({
+      type: 'patches',
+      patches: [
+        {type: 'unset', path: [], origin: 'remote'},
+        {type: 'setIfMissing', path: [], value: [], origin: 'remote'},
+      ],
+      snapshot: [],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        {
+          _type: 'block',
+          _key: 'k2',
+          style: 'normal',
+          markDefs: [],
+          children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+        },
+      ])
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'y')
+
+    await vi.waitFor(() => {
+      expect(patches).toEqual([
+        {
+          type: 'setIfMissing',
+          path: [],
+          value: [],
+          origin: 'local',
+        },
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [
+            {
+              _type: 'block',
+              _key: 'k2',
+              style: 'normal',
+              markDefs: [],
+              children: [{_type: 'span', _key: 'k3', text: '', marks: []}],
+            },
+          ],
+          origin: 'local',
+        },
+        {
+          type: 'diffMatchPatch',
+          path: [{_key: 'k2'}, 'children', {_key: 'k3'}, 'text'],
+          value: stringifyPatches(makePatches(makeDiff('', 'y'))),
+          origin: 'local',
+        },
+      ])
+    })
+  })
+
+  test('Scenario: A remote root `insert` before a genuine pristine block synced in via `update value` keeps both blocks', async () => {
+    const patches: Array<Patch> = []
+    const {editor, locator} = await createTestEditor({
+      keyGenerator: createTestKeyGenerator(),
+      schemaDefinition: defineSchema({}),
+      children: (
+        <EventListenerPlugin
+          on={(event) => {
+            if (event.type === 'patch') {
+              patches.push(event.patch)
+            }
+          }}
+        />
+      ),
+    })
+
+    await userEvent.click(locator)
+    await userEvent.type(locator, 'foo')
+
+    editor.send({
+      type: 'select',
+      at: {
+        anchor: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 0},
+        focus: {path: [{_key: 'k0'}, 'children', {_key: 'k1'}], offset: 3},
+      },
+    })
+    await userEvent.keyboard('{Backspace}')
+
+    await vi.waitFor(() => {
+      expect(patches.at(-1)).toEqual({
+        type: 'unset',
+        path: [],
+        origin: 'local',
+      })
+    })
+
+    const pristineForeignBlock: PortableTextBlock = {
+      _key: 'p0',
+      _type: 'block',
+      children: [{_key: 'p1', _type: 'span', text: '', marks: []}],
+      markDefs: [],
+      style: 'normal',
+    }
+
+    editor.send({type: 'update value', value: [pristineForeignBlock]})
+
+    await vi.waitFor(
+      () => {
+        expect(editor.getSnapshot().context.value).toEqual([
+          pristineForeignBlock,
+        ])
+      },
+      {timeout: 5000},
+    )
+
+    const contentBlock = {
+      _type: 'block',
+      _key: 'c0',
+      style: 'normal',
+      markDefs: [],
+      children: [{_type: 'span', _key: 'c1', text: 'baz', marks: []}],
+    }
+
+    editor.send({
+      type: 'patches',
+      patches: [
+        {
+          type: 'insert',
+          path: [0],
+          position: 'before',
+          items: [contentBlock],
+          origin: 'remote',
+        },
+      ],
+      snapshot: [contentBlock, pristineForeignBlock],
+    })
+
+    await vi.waitFor(() => {
+      expect(editor.getSnapshot().context.value).toEqual([
+        contentBlock,
+        pristineForeignBlock,
       ])
     })
   })


### PR DESCRIPTION
The editor decides whether an empty pristine block is saved content or its own placeholder, and it made that call by value equality, which cannot tell a host echoing the editor's own state back from genuine host content. That blind spot duplicated blocks in three confirmed ways, each pinned red here: after clearing a field, a genuine empty block arriving through `update value` was re-inserted by the next keystroke (`setIfMissing` plus an `insert` of a `_key` the document already holds, a permanent duplicate); the window survived arbitrary intervening content, because only a local rebuild disarmed the destroyed-field flag; and blocks created by collaborators through `patches` left no persistence evidence at all, so the first local edit duplicated them too.

The fix classifies at the source instead: the engine keeps a bounded ledger of the values it emitted with its own `mutation` events. An incoming changed sync that matches the ledger is an echo and asserts nothing; anything else is the host's word, records `lastSyncedValue`, and disarms the destroyed-field flag. Remote `patches` record the same evidence when a batch installs content at an empty root; a bare `setIfMissing` never records, since it can leave the editor holding only a normalization-minted placeholder the store does not have (pinned by its own scenario). The narrow behaviors the two previous fixes disclosed both retire: a genuinely persisted empty block is neither rebuilt over nor removed anymore, and the pending changesets from those fixes are amended so the release changelog tells one story.

Known limits, each degrading to the pre-fix behavior and no further: a host that transforms values before mirroring defeats the equality; a genuine host value identical to a recently emitted one (a host-level revert) classifies as an echo and skips recording; and a remote materialization racing this editor's still-in-flight `unset([])` can disarm the flag under store-order inversion. The value-equality overrides this invariant makes dead are deliberately left in place; a follow-up PR deletes them so this diff stays reviewable as the invariant change alone.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches collaborative sync, patch generation, and persistence heuristics; wrong echo classification could still mis-label host content, but behavior is bounded and covered by new integration tests.
> 
> **Overview**
> Fixes placeholder vs persisted empty-block handling under value-mirroring hosts by tracking **what this editor actually emitted**, instead of treating any matching `update value` as host persistence.
> 
> The engine keeps a **bounded `emittedValues` ledger** (filled when batched `mutation` events flush). On a changed value sync, if the incoming value equals a ledger entry it is treated as a **host echo**: `lastSyncedValue` is not updated and `valueUnsetEmitted` stays armed. Non-echo syncs still record persistence and disarm the cleared-field flag.
> 
> **Remote `patches`** can also record persistence when a batch **materializes the root** (root `insert` or non-empty root `set`; bare `setIfMissing` alone does not). Changelog changesets are consolidated so release notes describe one story.
> 
> This stops duplicate `_key` inserts after clear + genuine empty sync, treats collaborator blocks from `patches` as persisted on first local edit, and avoids dropping a real empty block when a remote root `insert` follows a local clear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed7dfd15dcf71950c6341501e46f2d3c370d2816. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->