### PR TITLE
chore(deps): exclude `scheduler` from the minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,10 @@ minimumReleaseAgeExclude:
   - react
   - react-dom
   - react-is
+  # ships from the React monorepo in lockstep with `react-dom`, whose new
+  # versions can require a `scheduler` published the same day; without the
+  # exclusion a `react-dom` bump fails to resolve inside the age window
+  - scheduler
   - markdown-it@14.1.1
   # Renovate security update: astro@7.2.8
   - astro@6.1.3 || 6.1.6 || 6.1.10 || 6.4.6 || 7.1.0 || 7.2.8


### PR DESCRIPTION
Renovate's react PRs arrive without a lockfile update and every CI job fails at `pnpm install --frozen-lockfile` (#3260). The workspace excludes `react` and `react-dom` from `minimumReleaseAge`, but not `scheduler`, which ships from the React monorepo in the same release: `react-dom@19.3.0` requires a `scheduler` published the same day, so pnpm's lockfile update fails inside the 3-day age window and Renovate opens the PR with manifest edits only.

This PR adds `scheduler` to `minimumReleaseAgeExclude`. Verified by regenerating the lockfile with the react catalog entries at ^19.3.0: it fails with `ERR_PNPM_NO_MATURE_MATCHING_VERSION` without the exclusion and resolves with it. Current resolution is unchanged. After this merges, ticking the rebase checkbox on #3260 should produce a green lockfile-included update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> pnpm workspace policy only; no runtime or application code changes.
> 
> **Overview**
> Adds **`scheduler`** to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`, alongside the existing **`react`** / **`react-dom`** exclusions.
> 
> That closes a gap where a **`react-dom`** bump can pull a same-day **`scheduler`** release that is still inside the 3-day **`minimumReleaseAge`** window, causing **`pnpm install --frozen-lockfile`** / lockfile regeneration to fail with **`ERR_PNPM_NO_MATURE_MATCHING_VERSION`** on Renovate React updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cba4d7ac89a6cbdb5c95748f3f424aaa07366ff4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->