### PR TITLE
fix: serialize images the parser would refuse as `json:object` fences

### DIFF
--- a/.changeset/guard-unparsable-image-src.md
+++ b/.changeset/guard-unparsable-image-src.md
@@ -1,0 +1,7 @@
+---
+'@portabletext/markdown': patch
+---
+
+fix: serialize images the parser would refuse as `json:object` fences
+
+An `image` whose `src` a Markdown parser would refuse (a `data:` URI outside `png`/`gif`/`jpeg`/`webp`, or a `javascript:`/`vbscript:`/`file:` URI) previously serialized as `![alt](src)` anyway; reparsing that markdown turned the image into literal text instead of an image object, destroying it. Such an image now serializes as a `json:object` fence (or, inline, a tagged code span), which reparses back to the identical image value. Images with an accepted `src` are unaffected.

--- a/packages/markdown/README.md
+++ b/packages/markdown/README.md
@@ -537,7 +537,7 @@ The conversion is driven by **Renderers**: functions that render Portable Text e
 
 Unknown types render as JSON code blocks by default; unknown styles, list items, and marks pass through their children.
 
-The default type renderers are collision-safe: because the serializer dispatches on the `_type` name alone, `code`, `html`, `image`, `callout`, and `table` fall back to the `unknownType` renderer (a JSON code block) when a value doesn't match the shape their renderer expects (say, your own differently-shaped `code` type); `horizontal-rule` has no shape to check and always renders `---`. Register your own `types.<name>` renderer to override how any of them serialize, or to handle a same-named type of a different shape.
+The default type renderers are collision-safe: because the serializer dispatches on the `_type` name alone, `code`, `html`, `image`, `callout`, and `table` fall back to the `unknownType` renderer (a JSON code block) when a value doesn't match the shape their renderer expects (say, your own differently-shaped `code` type); `horizontal-rule` has no shape to check and always renders `---`. `image` also falls back when `src` is a string a Markdown parser would refuse (a `javascript:`/`vbscript:`/`file:` URI, or a `data:` URI outside `png`/`gif`/`jpeg`/`webp`), so the value survives as a `json:object` fence instead of reparsing as literal text. Register your own `types.<name>` renderer to override how any of them serialize, or to handle a same-named type of a different shape.
 
 > **Note:** The `underline` renderer is included for Portable Text that uses it, but there's no standard Markdown syntax for underline, so it renders as HTML.
 

--- a/packages/markdown/src/from-portable-text/renderers/type.ts
+++ b/packages/markdown/src/from-portable-text/renderers/type.ts
@@ -1,6 +1,7 @@
 import {isTypedObject} from '@portabletext/schema'
 import {isPortableTextBlock} from '@portabletext/toolkit'
 import type {PortableTextBlock, TypedObject} from '@portabletext/types'
+import markdownit from 'markdown-it'
 import {
   escapeImageAndLinkText,
   escapeImageAndLinkTitle,
@@ -82,7 +83,7 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
   alt: string | undefined
   title: string | undefined
 }> = (options) => {
-  if (!isImageShaped(options.value)) {
+  if (!isImageShaped(options.value) || !linkValidator(options.value.src)) {
     return DefaultUnknownTypeRenderer(options)
   }
   const alt = escapeImageAndLinkText(options.value.alt ?? '')
@@ -91,6 +92,15 @@ export const DefaultImageRenderer: PortableTextTypeRenderer<{
     : ''
   return `![${alt}](${options.value.src}${title})`
 }
+
+// The markdown-it instance the parse side builds
+// (`to-portable-text/markdown-to-portable-text.ts`) never overrides
+// `validateLink`, so this default instance's validator is the one that
+// will run on reparse. It rejects `javascript:`/`vbscript:`/`file:` and
+// all `data:` URIs except png/gif/jpeg/webp; a `src` it rejects would
+// reparse as literal text instead of an image, so such a `src` is
+// guarded here the same way a malformed image shape is.
+const linkValidator = new markdownit().validateLink
 
 function isImageShaped(value: unknown): value is {
   src: string

--- a/packages/markdown/src/portable-text-to-markdown.test.ts
+++ b/packages/markdown/src/portable-text-to-markdown.test.ts
@@ -1432,11 +1432,94 @@ describe(portableTextToMarkdown.name, () => {
         '![](https://example.com/image.png)',
       )
     })
+
+    test('a `src` the parser refuses (an SVG data URI) falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'data:image/svg+xml;base64,PHN2Zy8+',
+        alt: 'logo',
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('a `src` the parser accepts (a PNG data URI) keeps its markdown form', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'data:image/png;base64,iVBORw0KGgo=',
+        alt: 'logo',
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        '![logo](data:image/png;base64,iVBORw0KGgo=)',
+      )
+    })
+
+    test('a `javascript:` protocol `src` falls back to fenced JSON', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'javascript:alert(1)',
+        alt: 'logo',
+      }
+
+      expect(portableTextToMarkdown([value])).toBe(
+        ['```json:object', JSON.stringify(value, null, 2), '```'].join('\n'),
+      )
+    })
+
+    test('the fenced form round-trips back to the identical image value', () => {
+      const keyGenerator = createTestKeyGenerator()
+      const value = {
+        _type: 'image',
+        _key: keyGenerator(),
+        src: 'data:image/svg+xml;base64,PHN2Zy8+',
+        alt: 'logo',
+      }
+      const markdown = portableTextToMarkdown([value])
+
+      expect(
+        markdownToPortableText(markdown, {
+          keyGenerator: createTestKeyGenerator(),
+        }),
+      ).toEqual([value])
+    })
   })
 
   describe('inline image', () => {
     const keyGenerator = createTestKeyGenerator()
     const markdown = 'foo ![alt text](https://example.com/image.png) bar'
+
+    test('a `src` the parser refuses (an SVG data URI) falls back to the tagged code span', () => {
+      const inlineImageValue = {
+        _type: 'image',
+        _key: 'img1',
+        src: 'data:image/svg+xml;base64,PHN2Zy8+',
+        alt: 'logo',
+      }
+      expect(
+        portableTextToMarkdown([
+          {
+            _type: 'block',
+            _key: 'b1',
+            style: 'normal',
+            markDefs: [],
+            children: [
+              {_type: 'span', _key: 's1', text: 'before ', marks: []},
+              inlineImageValue,
+              {_type: 'span', _key: 's2', text: ' after', marks: []},
+            ],
+          },
+        ]),
+      ).toBe(`before json:object\`${JSON.stringify(inlineImageValue)}\` after`)
+    })
 
     describe('supported by deserializer', () => {
       const portableText = markdownToPortableText(markdown, {keyGenerator})


### PR DESCRIPTION
A stored image whose `src` the markdown parser refuses no longer serializes to markdown that destroys it. Affected srcs: `data:` URIs outside `image/(gif|png|jpeg|webp)`, notably `data:image/svg+xml`, and script-ish protocols (`javascript:`, `vbscript:`, `file:`). Such images now serialize as a `json:object` fence (tagged code span inline) that reparses to the identical image, `_key` included; accepted srcs keep their `\![alt](src)` form unchanged.

The asymmetry this closes: the parse side runs markdown-it's default `validateLink` (an XSS guard), so `\![logo](data:image/svg+xml;…)` never forms an image token, it parses as literal text. A stored SVG-data-URI image therefore round-tripped into escaped text, and in the edit loop the type change refused the whole origin trace and churned every key in the document, the field report that surfaced this. The guard uses the parser's own validator (one module-level `validateLink` reference, and the parse side never overrides it), so there are no duplicated regexes to drift.

Pinned red-first: SVG data URI and `javascript:` srcs to the fence at block position and the code span inline, an accepted PNG data URI keeping its markdown form, and the fence round-tripping to the identical value. Probed and needing no fix: the link annotation's `href` cannot hit the same trap, `DefaultLinkRenderer`'s protocol allowlist is a strict subset of what `validateLink` accepts. One corner is inherent and documented on the tracking ticket instead: an SVG data-URI image typed *into* markdown still becomes plain text silently, markdown-it swallows the token before degradation reporting can see an image.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized serializer change for image `src` validation with round-trip tests; normal image URLs and accepted data URIs are unaffected.
> 
> **Overview**
> **`DefaultImageRenderer`** now rejects image `src` values that markdown-it's default **`validateLink`** would block (e.g. `javascript:` / `vbscript:` / `file:`, and `data:` URIs other than png/gif/jpeg/webp). Those images serialize as **`json:object`** fences (block) or tagged code spans (inline) via the existing **`unknownType`** path instead of `![alt](src)`, so PT→MD→PT preserves the image object instead of turning it into literal text.
> 
> Accepted `src` values are unchanged. The guard reuses a module-level **`markdown-it`** `validateLink` reference aligned with the parser. README and a changeset document the behavior; tests cover SVG/`javascript:` fallbacks, PNG data URIs, inline cases, and round-trip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95558566f8804c55a7feae39b6986f63ddee1d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->